### PR TITLE
add middleware to convert all requests with yaml content type to json

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,6 @@ ruff>=0.9.4
 black>=25.1.0
 mypy>=1.14.1
 pytest-mock>=3.14.0
+
+# Types
+types-PyYAML>=6.0

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,8 +1,9 @@
-import yaml
 import json
 
-from fastapi import Request, HTTPException
+import yaml
+from fastapi import HTTPException, Request, Response, status
 from starlette.datastructures import MutableHeaders
+from starlette.middleware.base import RequestResponseEndpoint
 
 from .api import router
 from .core.config import settings
@@ -12,17 +13,19 @@ app = create_application(router=router, settings=settings)
 
 
 @app.middleware("http")
-async def convert_yaml_to_json(request: Request, call_next):
+async def convert_yaml_to_json(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
+    """FastAPI middleware that will change all requests with a yaml content type to json."""
     body = await request.body()
     if request.headers.get("content-type") == "application/yaml":
         try:
             json_body = json.dumps(yaml.safe_load(body.decode("utf-8"))).encode()
         except Exception as e:
-            print(str(e))
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Unable to parse provided YAML configuration.",
-            )
+                detail="Unable to parse provided YAML configuration.",
+            ) from e
 
         request._body = json_body
         updated_headers = MutableHeaders(request._headers)
@@ -30,5 +33,5 @@ async def convert_yaml_to_json(request: Request, call_next):
         updated_headers["content-type"] = "application/json"
         request._headers = updated_headers
         request.scope.update(headers=request.headers.raw)
-    response = await call_next(request)
-    return response
+
+    return await call_next(request)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,5 +1,34 @@
+import yaml
+import json
+
+from fastapi import Request, HTTPException
+from starlette.datastructures import MutableHeaders
+
 from .api import router
 from .core.config import settings
 from .core.setup import create_application
 
 app = create_application(router=router, settings=settings)
+
+
+@app.middleware("http")
+async def convert_yaml_to_json(request: Request, call_next):
+    body = await request.body()
+    if request.headers.get("content-type") == "application/yaml":
+        try:
+            json_body = json.dumps(yaml.safe_load(body.decode("utf-8"))).encode()
+        except Exception as e:
+            print(str(e))
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unable to parse provided YAML configuration.",
+            )
+
+        request._body = json_body
+        updated_headers = MutableHeaders(request._headers)
+        updated_headers["content-length"] = str(len(json_body))
+        updated_headers["content-type"] = "application/json"
+        request._headers = updated_headers
+        request.scope.update(headers=request.headers.raw)
+    response = await call_next(request)
+    return response

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -39,10 +39,45 @@ valid_range_payload: dict[str, Any] = {
     "vpn": False,
 }
 
+valid_range_payload_yaml: str = """provider: aws
+vnc: false
+vpc:
+  cidr: 192.168.0.0/16
+  name: example-vpc-1
+  subnets:
+  - cidr: 192.168.1.0/24
+    hosts:
+    - hostname: example-host-1
+      os: debian_11
+      size: 1
+      spec: tiny
+      tags:
+      - web
+      - linux
+    name: example-subnet-1
+vpn: false
+"""
 
-def test_template_range_valid_payload() -> None:
+
+def test_template_range_valid_payload_json() -> None:
     """Test that we get a 200 and a valid uuid.UUID4 in response."""
     response = client.post(f"{BASE_ROUTE}/templates/range", json=valid_range_payload)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["id"]
+
+    # Validate UUID returned
+    uuid_response = response.json()["id"]
+    uuid_obj = uuid.UUID(uuid_response, version=4)
+    assert str(uuid_obj) == uuid_response
+
+
+def test_template_range_valid_payload_yaml() -> None:
+    """Test that we get a 200 and a valid uuid.UUID4 in response."""
+    response = client.post(
+        f"{BASE_ROUTE}/templates/range?yaml=true",
+        content=valid_range_payload_yaml,
+        headers={"content-type": "application/yaml"},
+    )
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["id"]
 

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -74,7 +74,7 @@ def test_template_range_valid_payload_json() -> None:
 def test_template_range_valid_payload_yaml() -> None:
     """Test that we get a 200 and a valid uuid.UUID4 in response."""
     response = client.post(
-        f"{BASE_ROUTE}/templates/range?yaml=true",
+        f"{BASE_ROUTE}/templates/range",
         content=valid_range_payload_yaml,
         headers={"content-type": "application/yaml"},
     )


### PR DESCRIPTION
## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.

## Description

This PR will allow users to supply yaml, which will be converted to JSON

This adds a FastAPI middleware to convert all requests with a content-type of yaml to one with a json body, content-type, etc.

Content type of `application/yaml` is used as per [RFC 9512](https://www.rfc-editor.org/rfc/rfc9512.html). 

I ended up going for content-type instead of the get param `?yaml=true`, as curl, fastapi test client, requests library, etc. all implicitly will set the content-type to json when a user provides json. I think this is better, since `?yaml=false` won't have to be provided to requests. 


Partially Fixes:  #24
Note: There is currently no support for subnet-level tagging 