### PR TITLE
Add ownership to templates and ranges + Implement auth endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 🐛 Bug Fix
 
-- Add template delete endpoints [#55](https://github.com/OpenLabsX/API/pull/55) ([@alexchristy](https://github.com/alexchristy))
+- Add template delete endpoints [#55](https://github.com/OpenLabs/API/pull/55) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -14,7 +14,7 @@
 
 #### 🐛 Bug Fix
 
-- Naming refactor [#52](https://github.com/OpenLabsX/API/pull/52) ([@alexchristy](https://github.com/alexchristy))
+- Naming refactor [#52](https://github.com/OpenLabs/API/pull/52) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -26,7 +26,7 @@
 
 #### 🚀 Enhancement
 
-- Cdktf [#50](https://github.com/OpenLabsX/API/pull/50) ([@Nareshp1](https://github.com/Nareshp1) [@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
+- Cdktf [#50](https://github.com/OpenLabs/API/pull/50) ([@Nareshp1](https://github.com/Nareshp1) [@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 3
 
@@ -40,11 +40,11 @@
 
 #### 🚀 Enhancement
 
-- SQLAlchemy  ORM Models ✅ [#46](https://github.com/OpenLabsX/API/pull/46) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
+- SQLAlchemy  ORM Models ✅ [#46](https://github.com/OpenLabs/API/pull/46) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 📝 Documentation
 
-- Add debug docker config to work with vscode debugging extension [#32](https://github.com/OpenLabsX/API/pull/32) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Add debug docker config to work with vscode debugging extension [#32](https://github.com/OpenLabs/API/pull/32) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 2
 
@@ -57,11 +57,11 @@
 
 #### 🚀 Enhancement
 
-- Specify minimum disk size for each OS [#35](https://github.com/OpenLabsX/API/pull/35) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Specify minimum disk size for each OS [#35](https://github.com/OpenLabs/API/pull/35) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 📝 Documentation
 
-- ignore .vscode folder to make my life easier [#30](https://github.com/OpenLabsX/API/pull/30) ([@Adamkadaban](https://github.com/Adamkadaban))
+- ignore .vscode folder to make my life easier [#30](https://github.com/OpenLabs/API/pull/30) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 1
 
@@ -73,8 +73,8 @@
 
 #### 🐛 Bug Fix
 
-- Ignore enums directory when running black so we can have nice spacing [#23](https://github.com/OpenLabsX/API/pull/23) ([@Adamkadaban](https://github.com/Adamkadaban))
-- add .swp to gitignore to make my life easier [#21](https://github.com/OpenLabsX/API/pull/21) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Ignore enums directory when running black so we can have nice spacing [#23](https://github.com/OpenLabs/API/pull/23) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add .swp to gitignore to make my life easier [#21](https://github.com/OpenLabs/API/pull/21) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 1
 
@@ -86,7 +86,7 @@
 
 #### 🐛 Bug Fix
 
-- Update Mypy Precommit Dependencies [#25](https://github.com/OpenLabsX/API/pull/25) ([@alexchristy](https://github.com/alexchristy))
+- Update Mypy Precommit Dependencies [#25](https://github.com/OpenLabs/API/pull/25) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -98,11 +98,11 @@
 
 #### 🚀 Enhancement
 
-- add some operating system AMIs and URNs [#11](https://github.com/OpenLabsX/API/pull/11) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add some operating system AMIs and URNs [#11](https://github.com/OpenLabs/API/pull/11) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 📝 Documentation
 
-- Clarify Docker Documentation [#19](https://github.com/OpenLabsX/API/pull/19) ([@alexchristy](https://github.com/alexchristy))
+- Clarify Docker Documentation [#19](https://github.com/OpenLabs/API/pull/19) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 2
 
@@ -115,7 +115,7 @@
 
 #### 🚀 Enhancement
 
-- Add Docker configurations [#17](https://github.com/OpenLabsX/API/pull/17) ([@alexchristy](https://github.com/alexchristy))
+- Add Docker configurations [#17](https://github.com/OpenLabs/API/pull/17) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -127,7 +127,7 @@
 
 #### 🐛 Bug Fix
 
-- add codeowners file so we are auto requested for review [#12](https://github.com/OpenLabsX/API/pull/12) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add codeowners file so we are auto requested for review [#12](https://github.com/OpenLabs/API/pull/12) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 1
 
@@ -139,15 +139,15 @@
 
 #### 🚀 Enhancement
 
-- Project Boilerplate [#3](https://github.com/OpenLabsX/API/pull/3) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
+- Project Boilerplate [#3](https://github.com/OpenLabs/API/pull/3) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 🐛 Bug Fix
 
-- Working Auto Release GH App Bypass [#6](https://github.com/OpenLabsX/API/pull/6) ([@alexchristy](https://github.com/alexchristy))
-- Auto release GitHub App [#5](https://github.com/OpenLabsX/API/pull/5) ([@alexchristy](https://github.com/alexchristy))
-- Remove workflow permission from release.yml workflow [#4](https://github.com/OpenLabsX/API/pull/4) ([@alexchristy](https://github.com/alexchristy))
-- Add aws and azure size mappings [#2](https://github.com/OpenLabsX/API/pull/2) ([@Adamkadaban](https://github.com/Adamkadaban))
-- add classes and enums [#1](https://github.com/OpenLabsX/API/pull/1) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Working Auto Release GH App Bypass [#6](https://github.com/OpenLabs/API/pull/6) ([@alexchristy](https://github.com/alexchristy))
+- Auto release GitHub App [#5](https://github.com/OpenLabs/API/pull/5) ([@alexchristy](https://github.com/alexchristy))
+- Remove workflow permission from release.yml workflow [#4](https://github.com/OpenLabs/API/pull/4) ([@alexchristy](https://github.com/alexchristy))
+- Add aws and azure size mappings [#2](https://github.com/OpenLabs/API/pull/2) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add classes and enums [#1](https://github.com/OpenLabs/API/pull/1) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### ⚠️ Pushed to `main`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 🐛 Bug Fix
 
-- Add template delete endpoints [#55](https://github.com/OpenLabs/API/pull/55) ([@alexchristy](https://github.com/alexchristy))
+- Add template delete endpoints [#55](https://github.com/OpenLabsHQ/API/pull/55) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -14,7 +14,7 @@
 
 #### 🐛 Bug Fix
 
-- Naming refactor [#52](https://github.com/OpenLabs/API/pull/52) ([@alexchristy](https://github.com/alexchristy))
+- Naming refactor [#52](https://github.com/OpenLabsHQ/API/pull/52) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -26,7 +26,7 @@
 
 #### 🚀 Enhancement
 
-- Cdktf [#50](https://github.com/OpenLabs/API/pull/50) ([@Nareshp1](https://github.com/Nareshp1) [@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
+- Cdktf [#50](https://github.com/OpenLabsHQ/API/pull/50) ([@Nareshp1](https://github.com/Nareshp1) [@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 3
 
@@ -40,11 +40,11 @@
 
 #### 🚀 Enhancement
 
-- SQLAlchemy  ORM Models ✅ [#46](https://github.com/OpenLabs/API/pull/46) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
+- SQLAlchemy  ORM Models ✅ [#46](https://github.com/OpenLabsHQ/API/pull/46) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 📝 Documentation
 
-- Add debug docker config to work with vscode debugging extension [#32](https://github.com/OpenLabs/API/pull/32) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Add debug docker config to work with vscode debugging extension [#32](https://github.com/OpenLabsHQ/API/pull/32) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 2
 
@@ -57,11 +57,11 @@
 
 #### 🚀 Enhancement
 
-- Specify minimum disk size for each OS [#35](https://github.com/OpenLabs/API/pull/35) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Specify minimum disk size for each OS [#35](https://github.com/OpenLabsHQ/API/pull/35) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 📝 Documentation
 
-- ignore .vscode folder to make my life easier [#30](https://github.com/OpenLabs/API/pull/30) ([@Adamkadaban](https://github.com/Adamkadaban))
+- ignore .vscode folder to make my life easier [#30](https://github.com/OpenLabsHQ/API/pull/30) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 1
 
@@ -73,8 +73,8 @@
 
 #### 🐛 Bug Fix
 
-- Ignore enums directory when running black so we can have nice spacing [#23](https://github.com/OpenLabs/API/pull/23) ([@Adamkadaban](https://github.com/Adamkadaban))
-- add .swp to gitignore to make my life easier [#21](https://github.com/OpenLabs/API/pull/21) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Ignore enums directory when running black so we can have nice spacing [#23](https://github.com/OpenLabsHQ/API/pull/23) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add .swp to gitignore to make my life easier [#21](https://github.com/OpenLabsHQ/API/pull/21) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 1
 
@@ -86,7 +86,7 @@
 
 #### 🐛 Bug Fix
 
-- Update Mypy Precommit Dependencies [#25](https://github.com/OpenLabs/API/pull/25) ([@alexchristy](https://github.com/alexchristy))
+- Update Mypy Precommit Dependencies [#25](https://github.com/OpenLabsHQ/API/pull/25) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -98,11 +98,11 @@
 
 #### 🚀 Enhancement
 
-- add some operating system AMIs and URNs [#11](https://github.com/OpenLabs/API/pull/11) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add some operating system AMIs and URNs [#11](https://github.com/OpenLabsHQ/API/pull/11) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 📝 Documentation
 
-- Clarify Docker Documentation [#19](https://github.com/OpenLabs/API/pull/19) ([@alexchristy](https://github.com/alexchristy))
+- Clarify Docker Documentation [#19](https://github.com/OpenLabsHQ/API/pull/19) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 2
 
@@ -115,7 +115,7 @@
 
 #### 🚀 Enhancement
 
-- Add Docker configurations [#17](https://github.com/OpenLabs/API/pull/17) ([@alexchristy](https://github.com/alexchristy))
+- Add Docker configurations [#17](https://github.com/OpenLabsHQ/API/pull/17) ([@alexchristy](https://github.com/alexchristy))
 
 #### Authors: 1
 
@@ -127,7 +127,7 @@
 
 #### 🐛 Bug Fix
 
-- add codeowners file so we are auto requested for review [#12](https://github.com/OpenLabs/API/pull/12) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add codeowners file so we are auto requested for review [#12](https://github.com/OpenLabsHQ/API/pull/12) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### Authors: 1
 
@@ -139,15 +139,15 @@
 
 #### 🚀 Enhancement
 
-- Project Boilerplate [#3](https://github.com/OpenLabs/API/pull/3) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
+- Project Boilerplate [#3](https://github.com/OpenLabsHQ/API/pull/3) ([@alexchristy](https://github.com/alexchristy) [@Adamkadaban](https://github.com/Adamkadaban))
 
 #### 🐛 Bug Fix
 
-- Working Auto Release GH App Bypass [#6](https://github.com/OpenLabs/API/pull/6) ([@alexchristy](https://github.com/alexchristy))
-- Auto release GitHub App [#5](https://github.com/OpenLabs/API/pull/5) ([@alexchristy](https://github.com/alexchristy))
-- Remove workflow permission from release.yml workflow [#4](https://github.com/OpenLabs/API/pull/4) ([@alexchristy](https://github.com/alexchristy))
-- Add aws and azure size mappings [#2](https://github.com/OpenLabs/API/pull/2) ([@Adamkadaban](https://github.com/Adamkadaban))
-- add classes and enums [#1](https://github.com/OpenLabs/API/pull/1) ([@Adamkadaban](https://github.com/Adamkadaban))
+- Working Auto Release GH App Bypass [#6](https://github.com/OpenLabsHQ/API/pull/6) ([@alexchristy](https://github.com/alexchristy))
+- Auto release GitHub App [#5](https://github.com/OpenLabsHQ/API/pull/5) ([@alexchristy](https://github.com/alexchristy))
+- Remove workflow permission from release.yml workflow [#4](https://github.com/OpenLabsHQ/API/pull/4) ([@alexchristy](https://github.com/alexchristy))
+- Add aws and azure size mappings [#2](https://github.com/OpenLabsHQ/API/pull/2) ([@Adamkadaban](https://github.com/Adamkadaban))
+- add classes and enums [#1](https://github.com/OpenLabsHQ/API/pull/1) ([@Adamkadaban](https://github.com/Adamkadaban))
 
 #### ⚠️ Pushed to `main`
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,10 +2,25 @@ FROM python:3.12-slim
 
 WORKDIR /code
 
-# For dynamic versioning
-RUN apt-get update && apt-get install -y git \
+RUN apt-get update && apt-get install -y git curl \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && apt-get install -y gnupg software-properties-common \
+    && apt-get install -y wget \
+    && apt-get install -y gnupg2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | \
+    gpg --dearmor | \
+    tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+
+RUN echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+    https://apt.releases.hashicorp.com bookworm main" | \
+    tee /etc/apt/sources.list.d/hashicorp.list
+
+RUN apt-get update && apt-get install -y terraform
+
 
 # Install debugpy for debugging
 RUN pip install --no-cache-dir debugpy
@@ -13,6 +28,14 @@ RUN pip install --no-cache-dir debugpy
 # Install python dependencies
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+# Set up terraform cache
+WORKDIR src/app/core/cdktf
+RUN mkdir -p "/root/.terraform.d/plugin-cache"
+COPY src/app/core/cdktf/.terraformrc /root/.terraformrc
+RUN terraform init
+RUN rm -rf .terraform*
+WORKDIR /code
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -156,40 +156,40 @@ All tests are located in `tests/`. The structure of the `tests/` directory mirro
 src/
 └── app
     ├── api
-    │   └── v1                  # API Version 1 routes (/v1)
-    |       |                   # ------------------------- #
-    │       ├── auth.py         # /auth routes
-    │       ├── health.py       # /health routes
-    │       ├── ranges.py       # /ranges routes
-    │       ├── templates.py    # /templates routes
-    │       └── users.py        # /users routes
+    │   └── v1                   # API Version 1 routes (/v1)
+    |       |                    # ------------------------- #
+    │       ├── auth.py          # /auth routes
+    │       ├── health.py        # /health routes
+    │       ├── ranges.py        # /ranges routes
+    │       ├── templates.py     # /templates routes
+    │       └── users.py         # /users routes
     |
-    ├── core                    # Core Application Logic
-    |   |                       # ---------------------- #
-    │   ├── auth/               # Authentication utilities
+    ├── core                     # Core Application Logic
+    |   |                        # ---------------------- #
+    │   ├── auth/                # Authentication utilities
     │   │   └── auth.py
-    │   ├── cdktf/              # CDKTF Libraries
-    │   │   └── aws/            # AWS provider configuration
-    │   ├── config.py           # Application settings
-    │   ├── db                  # Database configuration
+    │   ├── cdktf/               # CDKTF Libraries
+    │   │   └── aws/             # AWS provider configuration
+    │   ├── config.py            # Application settings
+    │   ├── db                   # Database configuration
     │   │   └── database.py
-    │   ├── logger.py           # Shared logger utility
-    │   └── setup.py            # Application setup logic
+    │   ├── logger.py            # Shared logger utility
+    │   └── setup.py             # Application setup logic
     | 
-    ├── crud                    # Database CRUD operations
+    ├── crud                     # Database CRUD operations
     │   ├── crud_host_templates.py
     │   ├── crud_range_templates.py
     │   ├── crud_subnet_templates.py
     │   ├── crud_users.py
     │   └── crud_vpc_templates.py
     |
-    ├── enums                   # Enums (Constants)
-    |   |                       # ---------------- #
+    ├── enums                    # Enums (Constants)
+    |   |                        # ---------------- #
     │   ├── operating_systems.py # OS configurations
-    │   ├── providers.py        # Defined cloud providers
-    │   └── specs.py            # Preset VM hardware configurations
+    │   ├── providers.py         # Defined cloud providers
+    │   └── specs.py             # Preset VM hardware configurations
     |
-    ├── models                  # Database Models
+    ├── models                   # Database Models
     │   ├── secret_model.py
     │   ├── template_base_model.py
     │   ├── template_host_model.py
@@ -198,8 +198,8 @@ src/
     │   ├── template_vpc_model.py
     │   └── user_model.py
     |
-    ├── schemas                 # API Schema (Objects)
-    |   |                       # ------------------ #
+    ├── schemas                  # API Schema (Objects)
+    |   |                        # ------------------ #
     │   ├── secret_schema.py
     │   ├── template_host_schema.py
     │   ├── template_range_schema.py
@@ -207,15 +207,15 @@ src/
     │   ├── template_vpc_schema.py
     │   └── user_schema.py
     |
-    ├── utils                   # Utility Functions
+    ├── utils                    # Utility Functions
     │   └── cdktf_utils.py
     |
-    ├── validators              # Data Validation
-    |   |                       # --------------- #
-    │   ├── id.py               # ID validation
-    │   └── network.py          # Networking config input validation
+    ├── validators               # Data Validation
+    |   |                        # --------------- #
+    │   ├── id.py                # ID validation
+    │   └── network.py           # Networking config input validation
     |
-    └── main.py                 # Main App Entry Point
+    └── main.py                  # Main App Entry Point
 ```
 
 ## VScode Extensions

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ ADMIN_EMAIL=admin@test.com        # Default admin email
 ADMIN_PASSWORD=admin123           # Default admin password
 ADMIN_NAME=Administrator          # Default admin name
 # Admin user is automatically created when database is initialized
+
+# Authentication Configuration
+SECRET_KEY=your-secret-key-here   # JWT token signing key (CHANGE THIS!)
 ```
 </details>
 
@@ -190,7 +193,7 @@ src/
     │   └── specs.py             # Preset VM hardware configurations
     |
     ├── models                   # Database Models
-    │   ├── secret_model.py
+    │   ├── secret_model.py        # Encrypted cloud provider credentials (AWS, Azure)
     │   ├── template_base_model.py
     │   ├── template_host_model.py
     │   ├── template_range_model.py
@@ -200,7 +203,7 @@ src/
     |
     ├── schemas                  # API Schema (Objects)
     |   |                        # ------------------ #
-    │   ├── secret_schema.py
+    │   ├── secret_schema.py      # Cloud provider credential schemas
     │   ├── template_host_schema.py
     │   ├── template_range_schema.py
     │   ├── template_subnet_schema.py
@@ -208,7 +211,8 @@ src/
     │   └── user_schema.py
     |
     ├── utils                    # Utility Functions
-    │   └── cdktf_utils.py
+    │   ├── cdktf_utils.py       # CDKTF configuration utilities
+    │   └── crypto.py            # Cryptography utilities for encrypting cloud provider credentials
     |
     ├── validators               # Data Validation
     |   |                        # --------------- #

--- a/README.md
+++ b/README.md
@@ -158,31 +158,62 @@ src/
     ├── api
     │   └── v1                  # API Version 1 routes (/v1)
     |       |                   # ------------------------- #
+    │       ├── auth.py         # /auth routes
     │       ├── health.py       # /health routes
-    │       └── templates.py    # /templates routes
+    │       ├── ranges.py       # /ranges routes
+    │       ├── templates.py    # /templates routes
+    │       └── users.py        # /users routes
     |
     ├── core                    # Core Application Logic
     |   |                       # ---------------------- #
+    │   ├── auth/               # Authentication utilities
+    │   │   └── auth.py
     │   ├── cdktf/              # CDKTF Libraries
+    │   │   └── aws/            # AWS provider configuration
     │   ├── config.py           # Application settings
     │   ├── db                  # Database configuration
     │   │   └── database.py
     │   ├── logger.py           # Shared logger utility
     │   └── setup.py            # Application setup logic
     | 
+    ├── crud                    # Database CRUD operations
+    │   ├── crud_host_templates.py
+    │   ├── crud_range_templates.py
+    │   ├── crud_subnet_templates.py
+    │   ├── crud_users.py
+    │   └── crud_vpc_templates.py
+    |
     ├── enums                   # Enums (Constants)
     |   |                       # ---------------- #
+    │   ├── operating_systems.py # OS configurations
     │   ├── providers.py        # Defined cloud providers
     │   └── specs.py            # Preset VM hardware configurations
     |
+    ├── models                  # Database Models
+    │   ├── secret_model.py
+    │   ├── template_base_model.py
+    │   ├── template_host_model.py
+    │   ├── template_range_model.py
+    │   ├── template_subnet_model.py
+    │   ├── template_vpc_model.py
+    │   └── user_model.py
+    |
     ├── schemas                 # API Schema (Objects)
     |   |                       # ------------------ #
-    │   ├── openlabs.py         # OpenLabs network objects
-    │   └── templates.py        # Template objects
+    │   ├── secret_schema.py
+    │   ├── template_host_schema.py
+    │   ├── template_range_schema.py
+    │   ├── template_subnet_schema.py
+    │   ├── template_vpc_schema.py
+    │   └── user_schema.py
     |
-    └── validators              # Data Validation
+    ├── utils                   # Utility Functions
+    │   └── cdktf_utils.py
+    |
+    ├── validators              # Data Validation
     |   |                       # --------------- #
-    |   └── network.py          # Networking config input validation
+    │   ├── id.py               # ID validation
+    │   └── network.py          # Networking config input validation
     |
     └── main.py                 # Main App Entry Point
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ POSTGRES_DB=openlabsx
 
 # Docker Compose Configuration
 POSTGRES_DEBUG_PORT=5432  # Expose PostgreSQL on host port for debugging
+
+# Admin User Configuration (optional)
+ADMIN_EMAIL=admin@test.com        # Default admin email 
+ADMIN_PASSWORD=admin123           # Default admin password
+ADMIN_NAME=Administrator          # Default admin name
+# Admin user is automatically created when database is initialized
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ This workflow automatically creates GitHub tagged releases based on the tag of t
 
 5) Create a GitHub App
 
-    ***Note:** OpenLabsX already has the `auto-release-app` installed. Skip to step 7.*
+    ***Note:** OpenLabs already has the `auto-release-app` installed. Skip to step 7.*
 
     This allows us to enforce branch protection rules while allowing the Auto release tool to bypass the protections when running automated workflows. (Source: [Comment Link](https://github.com/orgs/community/discussions/13836#discussioncomment-8535364))
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ cdktf-cdktf-provider-aws>=19.52
 # Auth
 pyjwt
 bcrypt
+
+# Crypto
+cryptography>=41.0.0
+argon2-cffi>=23.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ setuptools-scm~=8.1
 # CDKTF
 cdktf>=0.20
 cdktf-cdktf-provider-aws>=19.52
+
+# Auth
+pyjwt
+bcrypt

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-"""Source code of the OpenLabsX API."""
+"""Source code of the OpenLabs API."""

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,1 +1,1 @@
-"""Base app of the OpenLabsX API."""
+"""Base app of the OpenLabs API."""

--- a/src/app/api/__init__.py
+++ b/src/app/api/__init__.py
@@ -1,4 +1,4 @@
-"""Base of OpenLabsX API."""
+"""Base of OpenLabs API."""
 
 from fastapi import APIRouter
 

--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -6,9 +6,11 @@ from .auth import router as auth_router
 from .health import router as health_router
 from .ranges import router as ranges_router
 from .templates import router as templates_router
+from .users import router as user_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(health_router)
 router.include_router(templates_router)
 router.include_router(ranges_router)
 router.include_router(auth_router)
+router.include_router(user_router)

--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -1,4 +1,4 @@
-"""Version 1 of the OpenLabsX API routes."""
+"""Version 1 of the OpenLabs API routes."""
 
 from fastapi import APIRouter
 

--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -5,8 +5,10 @@ from fastapi import APIRouter
 from .health import router as health_router
 from .ranges import router as ranges_router
 from .templates import router as templates_router
+from .auth import router as auth_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(health_router)
 router.include_router(templates_router)
 router.include_router(ranges_router)
+router.include_router(auth_router)

--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -2,10 +2,10 @@
 
 from fastapi import APIRouter
 
+from .auth import router as auth_router
 from .health import router as health_router
 from .ranges import router as ranges_router
 from .templates import router as templates_router
-from .auth import router as auth_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(health_router)

--- a/src/app/api/v1/auth.py
+++ b/src/app/api/v1/auth.py
@@ -11,17 +11,14 @@ from sqlalchemy.ext.asyncio.session import AsyncSession
 from ...core.config import settings
 from ...core.db.database import async_get_db
 from ...crud.crud_users import create_user, get_user
-from ...schemas.user_schema import (
-    UserBaseSchema,
-    UserCreateBaseSchema,
-    UserID,
-)
+from ...schemas.message_schema import UserLoginMessageSchema, UserLogoutMessageSchema
+from ...schemas.user_schema import UserBaseSchema, UserCreateBaseSchema, UserID
 from ...utils.crypto import generate_master_key
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-@router.post("/login")
+@router.post("/login", response_model=UserLoginMessageSchema)
 async def login(
     openlabs_user: UserBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
@@ -133,7 +130,7 @@ async def register_new_user(
     return UserID.model_validate(created_user, from_attributes=True)
 
 
-@router.post("/logout")
+@router.post("/logout", response_model=UserLogoutMessageSchema)
 async def logout() -> JSONResponse:
     """Logout a user by clearing the authentication and encryption key cookies.
 

--- a/src/app/api/v1/auth.py
+++ b/src/app/api/v1/auth.py
@@ -20,6 +20,7 @@ from ...utils.crypto import generate_master_key
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+
 @router.post("/login")
 async def login(
     openlabs_user: UserBaseSchema,

--- a/src/app/api/v1/auth.py
+++ b/src/app/api/v1/auth.py
@@ -21,6 +21,8 @@ from bcrypt import checkpw
 
 import jwt
 
+from typing import Any
+
 from datetime import datetime, timedelta, UTC
 
 from ...core.config import settings
@@ -31,7 +33,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 async def login(
     openlabs_user: UserBaseSchema,
     db: AsyncSession = Depends(async_get_db), # noqa: B008
-) -> dict:
+) -> dict[str, str]:
     """Login a user.
 
     Args:
@@ -52,7 +54,7 @@ async def login(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials or user does not exist",
         )
-    
+
     user_hash = user.hashed_password
     user_id = user.id
 
@@ -61,9 +63,9 @@ async def login(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials or user does not exist",
         )
-        
-    
-    data_dict = {
+
+
+    data_dict: dict[str, Any] = {
         "user": str(user_id)
     }
 

--- a/src/app/api/v1/auth.py
+++ b/src/app/api/v1/auth.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta, UTC
 
 from ...core.config import settings
 
-router = APIRouter(prefix="/register", tags=["auth"])
+router = APIRouter(prefix="/auth", tags=["auth"])
 
 @router.post("/login")
 async def login(

--- a/src/app/api/v1/auth.py
+++ b/src/app/api/v1/auth.py
@@ -49,8 +49,8 @@ async def login(
 
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials or user does not exist",
         )
     
     user_hash = user.hashed_password
@@ -59,7 +59,7 @@ async def login(
     if not checkpw(openlabs_user.password.encode(), user_hash.encode()):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect password",
+            detail="Invalid credentials or user does not exist",
         )
         
     

--- a/src/app/api/v1/auth.py
+++ b/src/app/api/v1/auth.py
@@ -1,31 +1,19 @@
-from fastapi import APIRouter, HTTPException, status, Depends
-from sqlalchemy.ext.asyncio.session import AsyncSession
-
-from ...core.db.database import async_get_db
-from ...crud.crud_users import create_user, get_user
-
-from ...models.user_model import UserModel
-
-from ...schemas.user_schema import (
-    UserBaseSchema,
-    UserID,
-    UserCreateSchema,
-    UserCreateBaseSchema
-)
-from ...schemas.secret_schema import (
-    SecretBaseSchema,
-    SecretSchema,
-)
-
-from bcrypt import checkpw
-
-import jwt
-
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from datetime import datetime, timedelta, UTC
+import jwt
+from bcrypt import checkpw
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio.session import AsyncSession
 
 from ...core.config import settings
+from ...core.db.database import async_get_db
+from ...crud.crud_users import create_user, get_user
+from ...schemas.user_schema import (
+    UserBaseSchema,
+    UserCreateBaseSchema,
+    UserID,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -44,9 +32,8 @@ async def login(
     Returns:
     -------
         dict: token with JWT for the user.
+
     """
-
-
     user = await get_user(db, openlabs_user.email)
 
     if not user:
@@ -94,8 +81,8 @@ async def register_new_user(
     Returns:
     -------
         UserID: Identity of the created user.
-    """
 
+    """
     existing_user = await get_user(db, openlabs_user.email)
     if existing_user:
         raise HTTPException(
@@ -107,7 +94,7 @@ async def register_new_user(
     if not created_user:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Unable to create user",
+            detail="Unable to create user",
         )
 
     return UserID.model_validate(created_user, from_attributes=True)

--- a/src/app/api/v1/auth.py
+++ b/src/app/api/v1/auth.py
@@ -17,10 +17,11 @@ from ...schemas.user_schema import (
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+
 @router.post("/login")
 async def login(
     openlabs_user: UserBaseSchema,
-    db: AsyncSession = Depends(async_get_db), # noqa: B008
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
 ) -> dict[str, str]:
     """Login a user.
 
@@ -51,25 +52,23 @@ async def login(
             detail="Invalid credentials or user does not exist",
         )
 
-
-    data_dict: dict[str, Any] = {
-        "user": str(user_id)
-    }
+    data_dict: dict[str, Any] = {"user": str(user_id)}
 
     expire = datetime.now(UTC) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-
 
     data_dict.update({"exp": expire})
 
     return {
-        "token": jwt.encode(data_dict, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+        "token": jwt.encode(
+            data_dict, settings.SECRET_KEY, algorithm=settings.ALGORITHM
+        )
     }
 
 
 @router.post("/register")
 async def register_new_user(
     openlabs_user: UserCreateBaseSchema,
-    db: AsyncSession = Depends(async_get_db), # noqa: B008
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
 ) -> UserID:
     """Create a new user.
 

--- a/src/app/api/v1/ranges.py
+++ b/src/app/api/v1/ranges.py
@@ -93,11 +93,9 @@ async def deploy_range_from_template(
 
     # Check if we have the appropriate credentials based on the provider
     # For now we'll check AWS only since that's what's implemented
-    aws_secrets = decrypted_secrets.get("aws")
     if (
-        not aws_secrets
-        or not aws_secrets.get("aws_access_key")
-        or not aws_secrets.get("aws_secret_key")
+        not decrypted_secrets.aws_access_key
+        or not decrypted_secrets.aws_secret_key
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -107,8 +105,8 @@ async def deploy_range_from_template(
     # Set environment variables for AWS provider
     import os
 
-    os.environ["AWS_ACCESS_KEY_ID"] = aws_secrets["aws_access_key"]
-    os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secrets["aws_secret_key"]
+    os.environ["AWS_ACCESS_KEY_ID"] = decrypted_secrets.aws_access_key
+    os.environ["AWS_SECRET_ACCESS_KEY"] = decrypted_secrets.aws_secret_key
 
     for deploy_range in ranges:
         deployed_range_id = uuid.uuid4()

--- a/src/app/api/v1/ranges.py
+++ b/src/app/api/v1/ranges.py
@@ -50,11 +50,11 @@ async def deploy_range_from_template(
     # Decode the encryption key
     try:
         master_key = base64.b64decode(enc_key)
-    except Exception:
+    except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid encryption key. Please try logging in again.",
-        )
+        ) from e
 
     ranges: list[TemplateRangeSchema] = []
     for range_id in range_ids:
@@ -94,7 +94,11 @@ async def deploy_range_from_template(
     # Check if we have the appropriate credentials based on the provider
     # For now we'll check AWS only since that's what's implemented
     aws_secrets = decrypted_secrets.get("aws")
-    if not aws_secrets or not aws_secrets.get("aws_access_key") or not aws_secrets.get("aws_secret_key"):
+    if (
+        not aws_secrets
+        or not aws_secrets.get("aws_access_key")
+        or not aws_secrets.get("aws_secret_key")
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="AWS credentials not found or incomplete. Please add your AWS credentials.",
@@ -102,6 +106,7 @@ async def deploy_range_from_template(
 
     # Set environment variables for AWS provider
     import os
+
     os.environ["AWS_ACCESS_KEY_ID"] = aws_secrets["aws_access_key"]
     os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secrets["aws_secret_key"]
 

--- a/src/app/api/v1/ranges.py
+++ b/src/app/api/v1/ranges.py
@@ -47,7 +47,7 @@ async def deploy_range_from_template(
             )
 
         # Get the template
-        range_model = (await get_range_template(db, range_id, user_id=current_user.id),)
+        range_model = await get_range_template(db, range_id, user_id=current_user.id)
         if not range_model:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/src/app/api/v1/ranges.py
+++ b/src/app/api/v1/ranges.py
@@ -50,7 +50,7 @@ async def deploy_range_from_template(
 
         # Set user_id to None for admin to allow accessing any template
         user_id = None if current_user.is_admin else current_user.id
-        
+
         # Get the template
         range_model = await get_range_template(db, range_id, user_id=user_id)
         if not range_model:

--- a/src/app/api/v1/ranges.py
+++ b/src/app/api/v1/ranges.py
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/ranges", tags=["ranges"])
 async def deploy_range_from_template(
     range_ids: list[TemplateRangeID],
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user), # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, Any]:
     """Deploy range templates.
 
@@ -47,7 +47,7 @@ async def deploy_range_from_template(
             )
 
         # Get the template
-        range_model = await get_range_template(db, range_id, user_id=current_user.id),
+        range_model = (await get_range_template(db, range_id, user_id=current_user.id),)
         if not range_model:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/src/app/api/v1/ranges.py
+++ b/src/app/api/v1/ranges.py
@@ -6,7 +6,9 @@ from sqlalchemy.ext.asyncio.session import AsyncSession
 
 from ...core.config import settings
 from ...core.db.database import async_get_db
-from ...crud.crud_range_templates import get_range_template
+from ...core.auth.auth import get_current_user
+from ...models.user_model import UserModel
+from ...crud.crud_range_templates import get_range_template, is_range_template_owner
 from ...schemas.template_range_schema import TemplateRangeID, TemplateRangeSchema
 
 router = APIRouter(prefix="/ranges", tags=["ranges"])
@@ -16,14 +18,41 @@ router = APIRouter(prefix="/ranges", tags=["ranges"])
 async def deploy_range_from_template(
     range_ids: list[TemplateRangeID],
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),
 ) -> dict[str, Any]:
-    """Deploy range templates."""
+    """Deploy range templates.
+    
+    Args:
+    ----
+        range_ids (list[TemplateRangeID]): List of range template IDs to deploy.
+        db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
+        
+    Returns:
+    -------
+        dict[str, Any]: Deployment status.
+    """
     # Import CDKTF dependencies to avoid long import times
     from ...core.cdktf.aws.aws import create_aws_stack, deploy_infrastructure
 
     ranges: list[TemplateRangeSchema] = []
     for range_id in range_ids:
-        range_model = await get_range_template(db, range_id)
+        # Check if the user owns this template
+        is_owner = await is_range_template_owner(db, range_id, current_user.id)
+        if not is_owner:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"You don't have permission to deploy range with ID: {range_id.id}",
+            )
+        
+        # Get the template
+        range_model = await get_range_template(db, range_id, user_id=current_user.id), 
+        if not range_model:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Range template with ID: {range_id.id} not found or you don't have access to it!",
+            )
+            
         ranges.append(
             TemplateRangeSchema.model_validate(range_model, from_attributes=True)
         )

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -1,9 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio.session import AsyncSession
 
-from ...core.db.database import async_get_db
 from ...core.auth.auth import get_current_user
-from ...models.user_model import UserModel
+from ...core.db.database import async_get_db
 from ...crud.crud_host_templates import (
     create_host_template,
     get_host_template,
@@ -24,6 +23,7 @@ from ...crud.crud_vpc_templates import (
     get_vpc_template,
     get_vpc_template_headers,
 )
+from ...models.user_model import UserModel
 from ...schemas.template_host_schema import (
     TemplateHostBaseSchema,
     TemplateHostID,
@@ -55,7 +55,7 @@ router = APIRouter(prefix="/templates", tags=["templates"])
 @router.get("/ranges")
 async def get_range_template_headers_endpoint(
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_user), # noqa: B008
 ) -> list[TemplateRangeHeaderSchema]:
     """Get a list of range template headers.
 
@@ -86,9 +86,9 @@ async def get_range_template_headers_endpoint(
 
 @router.get("/ranges/{range_id}")
 async def get_range_template_endpoint(
-    range_id: str, 
+    range_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateRangeSchema:
     """Get a range template.
 
@@ -111,8 +111,8 @@ async def get_range_template_endpoint(
 
     # Get the template and check if the user is the owner
     range_template = await get_range_template(
-        db, 
-        TemplateRangeID(id=range_id), 
+        db,
+        TemplateRangeID(id=range_id),
         user_id=current_user.id
     )
 
@@ -129,7 +129,7 @@ async def get_range_template_endpoint(
 async def upload_range_template_endpoint(
     range_template: TemplateRangeBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateRangeID:
     """Upload a range template.
 
@@ -152,7 +152,7 @@ async def upload_range_template_endpoint(
 async def get_vpc_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_user), # noqa: B008
 ) -> list[TemplateVPCHeaderSchema]:
     """Get a list of vpc template headers.
 
@@ -169,8 +169,8 @@ async def get_vpc_template_headers_endpoint(
     """
     # Get only templates owned by the current user
     vpc_headers = await get_vpc_template_headers(
-        db, 
-        user_id=current_user.id, 
+        db,
+        user_id=current_user.id,
         standalone_only=standalone_only
     )
 
@@ -188,9 +188,9 @@ async def get_vpc_template_headers_endpoint(
 
 @router.get("/vpcs/{vpc_id}")
 async def get_vpc_template_endpoint(
-    vpc_id: str, 
+    vpc_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateVPCSchema:
     """Get a VPC template.
 
@@ -213,8 +213,8 @@ async def get_vpc_template_endpoint(
 
     # Get the template and check if the user is the owner
     vpc_template = await get_vpc_template(
-        db, 
-        TemplateVPCID(id=vpc_id), 
+        db,
+        TemplateVPCID(id=vpc_id),
         user_id=current_user.id
     )
 
@@ -231,7 +231,7 @@ async def get_vpc_template_endpoint(
 async def upload_vpc_template_endpoint(
     vpc_template: TemplateVPCBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateVPCID:
     """Upload a VPC template.
 
@@ -248,8 +248,8 @@ async def upload_vpc_template_endpoint(
     """
     # Create the template with the current user as the owner
     created_vpc = await create_vpc_template(
-        db, 
-        vpc_template, 
+        db,
+        vpc_template,
         owner_id=current_user.id
     )
     return TemplateVPCID.model_validate(created_vpc, from_attributes=True)
@@ -259,7 +259,7 @@ async def upload_vpc_template_endpoint(
 async def get_subnet_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user),
+    current_user: UserModel = Depends(get_current_user), # noqa: B008
 ) -> list[TemplateSubnetHeaderSchema]:
     """Get a list of subnet template headers.
 
@@ -293,9 +293,9 @@ async def get_subnet_template_headers_endpoint(
 
 @router.get("/subnets/{subnet_id}")
 async def get_subnet_template_endpoint(
-    subnet_id: str, 
+    subnet_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateSubnetSchema:
     """Get a subnet template.
 
@@ -331,7 +331,7 @@ async def get_subnet_template_endpoint(
 async def upload_subnet_template_endpoint(
     subnet_template: TemplateSubnetBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateSubnetID:
     """Upload a subnet template.
 
@@ -348,11 +348,11 @@ async def upload_subnet_template_endpoint(
     """
     # Create subnet with current user as owner
     created_subnet = await create_subnet_template(
-        db, 
+        db,
         subnet_template,
         owner_id=current_user.id
     )
-    
+
     return TemplateSubnetID.model_validate(created_subnet, from_attributes=True)
 
 
@@ -360,7 +360,7 @@ async def upload_subnet_template_endpoint(
 async def get_host_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> list[TemplateHostSchema]:
     """Get a list of host template headers.
 
@@ -394,9 +394,9 @@ async def get_host_template_headers_endpoint(
 
 @router.get("/hosts/{host_id}")
 async def get_host_template_endpoint(
-    host_id: str, 
+    host_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateHostSchema:
     """Get a host template.
 
@@ -432,7 +432,7 @@ async def get_host_template_endpoint(
 async def upload_host_template_endpoint(
     host_template: TemplateHostBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user)
+    current_user: UserModel = Depends(get_current_user) # noqa: B008
 ) -> TemplateHostID:
     """Upload a host template.
 
@@ -449,9 +449,9 @@ async def upload_host_template_endpoint(
     """
     # Create host with current user as owner
     created_host = await create_host_template(
-        db, 
+        db,
         host_template,
         owner_id=current_user.id
     )
-    
+
     return TemplateHostID.model_validate(created_host, from_attributes=True)

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -161,6 +161,7 @@ async def delete_range_template_endpoint(
     ----
         range_id (str): Id of the range template.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
@@ -303,6 +304,7 @@ async def delete_vpc_template_endpoint(
     ----
         vpc_id (str): Id of the VPC template.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
@@ -447,6 +449,7 @@ async def delete_subnet_template_endpoint(
     ----
         subnet_id (str): Id of the subnet template.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
@@ -592,6 +595,7 @@ async def delete_host_template_endpoint(
     ----
         host_id (str): Id of the host.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -79,7 +79,11 @@ async def get_range_template_headers_endpoint(
     range_headers = await get_range_template_headers(db, user_id=user_id)
 
     if not range_headers:
-        detail = "No range templates found!" if current_user.is_admin else "Unable to find any range templates that you own!"
+        detail = (
+            "No range templates found!"
+            if current_user.is_admin
+            else "Unable to find any range templates that you own!"
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=detail,
@@ -118,7 +122,7 @@ async def get_range_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
+
     # Get the template
     range_template = await get_range_template(
         db, TemplateRangeID(id=range_id), user_id=user_id
@@ -184,7 +188,7 @@ async def delete_range_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
+
     range_template = await get_range_template(
         db, TemplateRangeID(id=range_id), user_id=user_id
     )
@@ -227,14 +231,18 @@ async def get_vpc_template_headers_endpoint(
     """
     # If user is admin, get all templates, otherwise only get templates owned by the user
     user_id = None if current_user.is_admin else current_user.id
-    
+
     vpc_headers = await get_vpc_template_headers(
         db, user_id=user_id, standalone_only=standalone_only
     )
 
     if not vpc_headers:
         standalone_text = " standalone" if standalone_only else ""
-        detail = f"No{standalone_text} VPC templates found!" if current_user.is_admin else f"Unable to find any{standalone_text} VPC templates that you own!"
+        detail = (
+            f"No{standalone_text} VPC templates found!"
+            if current_user.is_admin
+            else f"Unable to find any{standalone_text} VPC templates that you own!"
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=detail,
@@ -273,11 +281,9 @@ async def get_vpc_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
+
     # Get the template
-    vpc_template = await get_vpc_template(
-        db, TemplateVPCID(id=vpc_id), user_id=user_id
-    )
+    vpc_template = await get_vpc_template(db, TemplateVPCID(id=vpc_id), user_id=user_id)
 
     if not vpc_template:
         raise HTTPException(
@@ -340,10 +346,8 @@ async def delete_vpc_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
-    vpc_template = await get_vpc_template(
-        db, TemplateVPCID(id=vpc_id), user_id=user_id
-    )
+
+    vpc_template = await get_vpc_template(db, TemplateVPCID(id=vpc_id), user_id=user_id)
 
     # Does not exist
     if not vpc_template:
@@ -383,7 +387,7 @@ async def get_subnet_template_headers_endpoint(
     """
     # If user is admin, get all templates, otherwise only get templates owned by the user
     user_id = None if current_user.is_admin else current_user.id
-    
+
     # Get subnet headers
     subnet_headers = await get_subnet_template_headers(
         db, standalone_only=standalone_only, user_id=user_id
@@ -391,7 +395,11 @@ async def get_subnet_template_headers_endpoint(
 
     if not subnet_headers:
         standalone_text = " standalone" if standalone_only else ""
-        detail = f"No{standalone_text} subnet templates found!" if current_user.is_admin else f"Unable to find any{standalone_text} subnet templates that you own!"
+        detail = (
+            f"No{standalone_text} subnet templates found!"
+            if current_user.is_admin
+            else f"Unable to find any{standalone_text} subnet templates that you own!"
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=detail,
@@ -430,7 +438,7 @@ async def get_subnet_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
+
     subnet_template = await get_subnet_template(
         db, TemplateSubnetID(id=subnet_id), user_id=user_id
     )
@@ -499,7 +507,7 @@ async def delete_subnet_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
+
     subnet_template = await get_subnet_template(
         db, TemplateSubnetID(id=subnet_id), user_id=user_id
     )
@@ -542,7 +550,7 @@ async def get_host_template_headers_endpoint(
     """
     # If user is admin, get all templates, otherwise only get templates owned by the user
     user_id = None if current_user.is_admin else current_user.id
-    
+
     # Get host headers
     host_headers = await get_host_template_headers(
         db, standalone_only=standalone_only, user_id=user_id
@@ -550,7 +558,11 @@ async def get_host_template_headers_endpoint(
 
     if not host_headers:
         standalone_text = " standalone" if standalone_only else ""
-        detail = f"No{standalone_text} host templates found!" if current_user.is_admin else f"Unable to find any{standalone_text} host templates that you own!"
+        detail = (
+            f"No{standalone_text} host templates found!"
+            if current_user.is_admin
+            else f"Unable to find any{standalone_text} host templates that you own!"
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=detail,
@@ -589,7 +601,7 @@ async def get_host_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
+
     host_template = await get_host_template(
         db, TemplateHostID(id=host_id), user_id=user_id
     )
@@ -658,7 +670,7 @@ async def delete_host_template_endpoint(
 
     # For admin users, don't filter by user_id to allow access to all templates
     user_id = None if current_user.is_admin else current_user.id
-    
+
     host_template = await get_host_template(
         db, TemplateHostID(id=host_id), user_id=user_id
     )

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -152,7 +152,8 @@ async def upload_range_template_endpoint(
 
 @router.delete("/ranges/{range_id}")
 async def delete_range_template_endpoint(
-    range_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    range_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a range template.
 
@@ -173,13 +174,13 @@ async def delete_range_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    range_template = await get_range_template(db, TemplateRangeID(id=range_id))
+    range_template = await get_range_template(db, TemplateRangeID(id=range_id), user_id=current_user.id)
 
     # Does not exist
     if not range_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Range template with id: {range_id} not found!",
+            detail=f"Range template with id: {range_id} not found or you don't have access to it!",
         )
 
     # Not standalone template
@@ -293,7 +294,8 @@ async def upload_vpc_template_endpoint(
 
 @router.delete("/vpcs/{vpc_id}")
 async def delete_vpc_template_endpoint(
-    vpc_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    vpc_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a VPC template.
 
@@ -314,13 +316,13 @@ async def delete_vpc_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    vpc_template = await get_vpc_template(db, TemplateVPCID(id=vpc_id))
+    vpc_template = await get_vpc_template(db, TemplateVPCID(id=vpc_id), user_id=current_user.id)
 
     # Does not exist
     if not vpc_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"VPC template with id: {vpc_id} not found!",
+            detail=f"VPC template with id: {vpc_id} not found or you don't have access to it!",
         )
 
     # Not standalone template
@@ -436,7 +438,8 @@ async def upload_subnet_template_endpoint(
 
 @router.delete("/subnets/{subnet_id}")
 async def delete_subnet_template_endpoint(
-    subnet_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    subnet_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a subnet template.
 
@@ -457,13 +460,13 @@ async def delete_subnet_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    subnet_template = await get_subnet_template(db, TemplateSubnetID(id=subnet_id))
+    subnet_template = await get_subnet_template(db, TemplateSubnetID(id=subnet_id), user_id=current_user.id)
 
     # Does not exist
     if not subnet_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Subnet template with id: {subnet_id} not found!",
+            detail=f"Subnet template with id: {subnet_id} not found or you don't have access to it!",
         )
 
     # Not standalone template
@@ -580,7 +583,8 @@ async def upload_host_template_endpoint(
 
 @router.delete("/hosts/{host_id}")
 async def delete_host_template_endpoint(
-    host_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    host_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a host template.
 
@@ -601,13 +605,13 @@ async def delete_host_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    host_template = await get_host_template(db, TemplateHostID(id=host_id))
+    host_template = await get_host_template(db, TemplateHostID(id=host_id), user_id=current_user.id)
 
     # Does not exist
     if not host_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Host with id: {host_id} not found!",
+            detail=f"Host with id: {host_id} not found or you don't have access to it!",
         )
 
     # Not standalone template

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -152,7 +152,8 @@ async def upload_range_template_endpoint(
 
 @router.delete("/ranges/{range_id}")
 async def delete_range_template_endpoint(
-    range_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    range_id: str,
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
     current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a range template.
@@ -175,7 +176,9 @@ async def delete_range_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    range_template = await get_range_template(db, TemplateRangeID(id=range_id), user_id=current_user.id)
+    range_template = await get_range_template(
+        db, TemplateRangeID(id=range_id), user_id=current_user.id
+    )
 
     # Does not exist
     if not range_template:
@@ -295,7 +298,8 @@ async def upload_vpc_template_endpoint(
 
 @router.delete("/vpcs/{vpc_id}")
 async def delete_vpc_template_endpoint(
-    vpc_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    vpc_id: str,
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
     current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a VPC template.
@@ -318,7 +322,9 @@ async def delete_vpc_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    vpc_template = await get_vpc_template(db, TemplateVPCID(id=vpc_id), user_id=current_user.id)
+    vpc_template = await get_vpc_template(
+        db, TemplateVPCID(id=vpc_id), user_id=current_user.id
+    )
 
     # Does not exist
     if not vpc_template:
@@ -440,7 +446,8 @@ async def upload_subnet_template_endpoint(
 
 @router.delete("/subnets/{subnet_id}")
 async def delete_subnet_template_endpoint(
-    subnet_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    subnet_id: str,
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
     current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a subnet template.
@@ -463,7 +470,9 @@ async def delete_subnet_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    subnet_template = await get_subnet_template(db, TemplateSubnetID(id=subnet_id), user_id=current_user.id)
+    subnet_template = await get_subnet_template(
+        db, TemplateSubnetID(id=subnet_id), user_id=current_user.id
+    )
 
     # Does not exist
     if not subnet_template:
@@ -583,10 +592,10 @@ async def upload_host_template_endpoint(
     return TemplateHostID.model_validate(created_host, from_attributes=True)
 
 
-
 @router.delete("/hosts/{host_id}")
 async def delete_host_template_endpoint(
-    host_id: str, db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    host_id: str,
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
     current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> bool:
     """Delete a host template.
@@ -609,7 +618,9 @@ async def delete_host_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    host_template = await get_host_template(db, TemplateHostID(id=host_id), user_id=current_user.id)
+    host_template = await get_host_template(
+        db, TemplateHostID(id=host_id), user_id=current_user.id
+    )
 
     # Does not exist
     if not host_template:

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -55,7 +55,7 @@ router = APIRouter(prefix="/templates", tags=["templates"])
 @router.get("/ranges")
 async def get_range_template_headers_endpoint(
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user), # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> list[TemplateRangeHeaderSchema]:
     """Get a list of range template headers.
 
@@ -88,7 +88,7 @@ async def get_range_template_headers_endpoint(
 async def get_range_template_endpoint(
     range_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateRangeSchema:
     """Get a range template.
 
@@ -111,9 +111,7 @@ async def get_range_template_endpoint(
 
     # Get the template and check if the user is the owner
     range_template = await get_range_template(
-        db,
-        TemplateRangeID(id=range_id),
-        user_id=current_user.id
+        db, TemplateRangeID(id=range_id), user_id=current_user.id
     )
 
     if not range_template:
@@ -129,7 +127,7 @@ async def get_range_template_endpoint(
 async def upload_range_template_endpoint(
     range_template: TemplateRangeBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateRangeID:
     """Upload a range template.
 
@@ -152,7 +150,7 @@ async def upload_range_template_endpoint(
 async def get_vpc_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user), # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> list[TemplateVPCHeaderSchema]:
     """Get a list of vpc template headers.
 
@@ -169,9 +167,7 @@ async def get_vpc_template_headers_endpoint(
     """
     # Get only templates owned by the current user
     vpc_headers = await get_vpc_template_headers(
-        db,
-        user_id=current_user.id,
-        standalone_only=standalone_only
+        db, user_id=current_user.id, standalone_only=standalone_only
     )
 
     if not vpc_headers:
@@ -190,7 +186,7 @@ async def get_vpc_template_headers_endpoint(
 async def get_vpc_template_endpoint(
     vpc_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateVPCSchema:
     """Get a VPC template.
 
@@ -213,9 +209,7 @@ async def get_vpc_template_endpoint(
 
     # Get the template and check if the user is the owner
     vpc_template = await get_vpc_template(
-        db,
-        TemplateVPCID(id=vpc_id),
-        user_id=current_user.id
+        db, TemplateVPCID(id=vpc_id), user_id=current_user.id
     )
 
     if not vpc_template:
@@ -231,7 +225,7 @@ async def get_vpc_template_endpoint(
 async def upload_vpc_template_endpoint(
     vpc_template: TemplateVPCBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateVPCID:
     """Upload a VPC template.
 
@@ -247,11 +241,7 @@ async def upload_vpc_template_endpoint(
 
     """
     # Create the template with the current user as the owner
-    created_vpc = await create_vpc_template(
-        db,
-        vpc_template,
-        owner_id=current_user.id
-    )
+    created_vpc = await create_vpc_template(db, vpc_template, owner_id=current_user.id)
     return TemplateVPCID.model_validate(created_vpc, from_attributes=True)
 
 
@@ -259,7 +249,7 @@ async def upload_vpc_template_endpoint(
 async def get_subnet_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user), # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> list[TemplateSubnetHeaderSchema]:
     """Get a list of subnet template headers.
 
@@ -295,7 +285,7 @@ async def get_subnet_template_headers_endpoint(
 async def get_subnet_template_endpoint(
     subnet_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateSubnetSchema:
     """Get a subnet template.
 
@@ -316,7 +306,9 @@ async def get_subnet_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    subnet_template = await get_subnet_template(db, TemplateSubnetID(id=subnet_id), user_id=current_user.id)
+    subnet_template = await get_subnet_template(
+        db, TemplateSubnetID(id=subnet_id), user_id=current_user.id
+    )
 
     if not subnet_template:
         raise HTTPException(
@@ -331,7 +323,7 @@ async def get_subnet_template_endpoint(
 async def upload_subnet_template_endpoint(
     subnet_template: TemplateSubnetBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateSubnetID:
     """Upload a subnet template.
 
@@ -348,9 +340,7 @@ async def upload_subnet_template_endpoint(
     """
     # Create subnet with current user as owner
     created_subnet = await create_subnet_template(
-        db,
-        subnet_template,
-        owner_id=current_user.id
+        db, subnet_template, owner_id=current_user.id
     )
 
     return TemplateSubnetID.model_validate(created_subnet, from_attributes=True)
@@ -360,7 +350,7 @@ async def upload_subnet_template_endpoint(
 async def get_host_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> list[TemplateHostSchema]:
     """Get a list of host template headers.
 
@@ -396,7 +386,7 @@ async def get_host_template_headers_endpoint(
 async def get_host_template_endpoint(
     host_id: str,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateHostSchema:
     """Get a host template.
 
@@ -417,7 +407,9 @@ async def get_host_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    host_template = await get_host_template(db, TemplateHostID(id=host_id), user_id=current_user.id)
+    host_template = await get_host_template(
+        db, TemplateHostID(id=host_id), user_id=current_user.id
+    )
 
     if not host_template:
         raise HTTPException(
@@ -432,7 +424,7 @@ async def get_host_template_endpoint(
 async def upload_host_template_endpoint(
     host_template: TemplateHostBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-    current_user: UserModel = Depends(get_current_user) # noqa: B008
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
 ) -> TemplateHostID:
     """Upload a host template.
 
@@ -449,9 +441,7 @@ async def upload_host_template_endpoint(
     """
     # Create host with current user as owner
     created_host = await create_host_template(
-        db,
-        host_template,
-        owner_id=current_user.id
+        db, host_template, owner_id=current_user.id
     )
 
     return TemplateHostID.model_validate(created_host, from_attributes=True)

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio.session import AsyncSession
 
 from ...core.db.database import async_get_db
+from ...core.auth.auth import get_current_user
+from ...models.user_model import UserModel
 from ...crud.crud_host_templates import (
     create_host_template,
     get_host_template,
@@ -53,24 +55,27 @@ router = APIRouter(prefix="/templates", tags=["templates"])
 @router.get("/ranges")
 async def get_range_template_headers_endpoint(
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),
 ) -> list[TemplateRangeHeaderSchema]:
     """Get a list of range template headers.
 
     Args:
     ----
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        list[TemplateRangeID]: List of range template headers.
+        list[TemplateRangeID]: List of range template headers owned by the current user.
 
     """
-    range_headers = await get_range_template_headers(db)
+    # Get only templates owned by the current user
+    range_headers = await get_range_template_headers(db, user_id=current_user.id)
 
     if not range_headers:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Unable to find any range templates!",
+            detail="Unable to find any range templates that you own!",
         )
 
     return [
@@ -81,7 +86,9 @@ async def get_range_template_headers_endpoint(
 
 @router.get("/ranges/{range_id}")
 async def get_range_template_endpoint(
-    range_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    range_id: str, 
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateRangeSchema:
     """Get a range template.
 
@@ -89,10 +96,11 @@ async def get_range_template_endpoint(
     ----
         range_id (str): ID of the range.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        TemplateRangeSchema: Range template data from database.
+        TemplateRangeSchema: Range template data from database if it belongs to the user.
 
     """
     if not is_valid_uuid4(range_id):
@@ -101,12 +109,17 @@ async def get_range_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    range_template = await get_range_template(db, TemplateRangeID(id=range_id))
+    # Get the template and check if the user is the owner
+    range_template = await get_range_template(
+        db, 
+        TemplateRangeID(id=range_id), 
+        user_id=current_user.id
+    )
 
     if not range_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Range with id: {range_id} not found!",
+            detail=f"Range with id: {range_id} not found or you don't have access to it!",
         )
 
     return TemplateRangeSchema.model_validate(range_template, from_attributes=True)
@@ -116,6 +129,7 @@ async def get_range_template_endpoint(
 async def upload_range_template_endpoint(
     range_template: TemplateRangeBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateRangeID:
     """Upload a range template.
 
@@ -123,13 +137,14 @@ async def upload_range_template_endpoint(
     ----
         range_template (TemplateRangeBaseSchema): OpenLabs compliant range template object.
         db (AsynSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
         TemplateRangeID: Identity of the range template.
 
     """
-    created_range = await create_range_template(db, range_template)
+    created_range = await create_range_template(db, range_template, current_user.id)
     return TemplateRangeID.model_validate(created_range, from_attributes=True)
 
 
@@ -137,6 +152,7 @@ async def upload_range_template_endpoint(
 async def get_vpc_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),
 ) -> list[TemplateVPCHeaderSchema]:
     """Get a list of vpc template headers.
 
@@ -144,18 +160,24 @@ async def get_vpc_template_headers_endpoint(
     ----
         standalone_only (bool): Return only standalone VPC templates (not part of a range template). Defaults to True.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        list[TemplateVPCID]: List of vpc template headers.
+        list[TemplateVPCID]: List of vpc template headers owned by the current user.
 
     """
-    vpc_headers = await get_vpc_template_headers(db, standalone_only=standalone_only)
+    # Get only templates owned by the current user
+    vpc_headers = await get_vpc_template_headers(
+        db, 
+        user_id=current_user.id, 
+        standalone_only=standalone_only
+    )
 
     if not vpc_headers:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Unable to find any{" standalone" if standalone_only else ""} vpc templates!",
+            detail=f"Unable to find any{" standalone" if standalone_only else ""} vpc templates that you own!",
         )
 
     return [
@@ -166,7 +188,9 @@ async def get_vpc_template_headers_endpoint(
 
 @router.get("/vpcs/{vpc_id}")
 async def get_vpc_template_endpoint(
-    vpc_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    vpc_id: str, 
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateVPCSchema:
     """Get a VPC template.
 
@@ -174,10 +198,11 @@ async def get_vpc_template_endpoint(
     ----
         vpc_id (str): ID of the VPC template.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        TemplateVPCSchema: Template VPC data from database.
+        TemplateVPCSchema: Template VPC data from database if it belongs to the user.
 
     """
     if not is_valid_uuid4(vpc_id):
@@ -186,12 +211,17 @@ async def get_vpc_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    vpc_template = await get_vpc_template(db, TemplateVPCID(id=vpc_id))
+    # Get the template and check if the user is the owner
+    vpc_template = await get_vpc_template(
+        db, 
+        TemplateVPCID(id=vpc_id), 
+        user_id=current_user.id
+    )
 
     if not vpc_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"VPC with id: {vpc_id} not found!",
+            detail=f"VPC with id: {vpc_id} not found or you don't have access to it!",
         )
 
     return TemplateVPCSchema.model_validate(vpc_template, from_attributes=True)
@@ -201,6 +231,7 @@ async def get_vpc_template_endpoint(
 async def upload_vpc_template_endpoint(
     vpc_template: TemplateVPCBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateVPCID:
     """Upload a VPC template.
 
@@ -208,13 +239,19 @@ async def upload_vpc_template_endpoint(
     ----
         vpc_template (TemplateVPCBaseSchema): OpenLabs compliant VPC object.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
         TemplateVPCID: Identity of the VPC template.
 
     """
-    created_vpc = await create_vpc_template(db, vpc_template)
+    # Create the template with the current user as the owner
+    created_vpc = await create_vpc_template(
+        db, 
+        vpc_template, 
+        owner_id=current_user.id
+    )
     return TemplateVPCID.model_validate(created_vpc, from_attributes=True)
 
 
@@ -222,6 +259,7 @@ async def upload_vpc_template_endpoint(
 async def get_subnet_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user),
 ) -> list[TemplateSubnetHeaderSchema]:
     """Get a list of subnet template headers.
 
@@ -229,20 +267,22 @@ async def get_subnet_template_headers_endpoint(
     ----
         standalone_only (bool): Return only standalone subnet templates (not part of a range/vpc template). Defaults to True.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        list[TemplateSubnetHeaderSchema]: List of subnet template headers.
+        list[TemplateSubnetHeaderSchema]: List of subnet template headers owned by the current user.
 
     """
+    # Get subnet headers filtered by owner_id
     subnet_headers = await get_subnet_template_headers(
-        db, standalone_only=standalone_only
+        db, standalone_only=standalone_only, user_id=current_user.id
     )
 
     if not subnet_headers:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Unable to find any{" standalone" if standalone_only else ""} subnet templates!",
+            detail=f"Unable to find any{" standalone" if standalone_only else ""} subnet templates that you own!",
         )
 
     return [
@@ -253,7 +293,9 @@ async def get_subnet_template_headers_endpoint(
 
 @router.get("/subnets/{subnet_id}")
 async def get_subnet_template_endpoint(
-    subnet_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    subnet_id: str, 
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateSubnetSchema:
     """Get a subnet template.
 
@@ -261,10 +303,11 @@ async def get_subnet_template_endpoint(
     ----
         subnet_id (str): ID of the subnet.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        TemplateSubnetSchema: Subnet data from database.
+        TemplateSubnetSchema: Subnet data from database if it belongs to the user.
 
     """
     if not is_valid_uuid4(subnet_id):
@@ -273,12 +316,12 @@ async def get_subnet_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    subnet_template = await get_subnet_template(db, TemplateSubnetID(id=subnet_id))
+    subnet_template = await get_subnet_template(db, TemplateSubnetID(id=subnet_id), user_id=current_user.id)
 
     if not subnet_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Subnet with id: {subnet_id} not found!",
+            detail=f"Subnet with id: {subnet_id} not found or you don't have access to it!",
         )
 
     return TemplateSubnetSchema.model_validate(subnet_template, from_attributes=True)
@@ -288,6 +331,7 @@ async def get_subnet_template_endpoint(
 async def upload_subnet_template_endpoint(
     subnet_template: TemplateSubnetBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateSubnetID:
     """Upload a subnet template.
 
@@ -295,13 +339,20 @@ async def upload_subnet_template_endpoint(
     ----
         subnet_template (TemplateSubnetBaseSchema): OpenLabs compliant subnet template object.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
         TemplateSubnetID: Identity of the subnet template.
 
     """
-    created_subnet = await create_subnet_template(db, subnet_template)
+    # Create subnet with current user as owner
+    created_subnet = await create_subnet_template(
+        db, 
+        subnet_template,
+        owner_id=current_user.id
+    )
+    
     return TemplateSubnetID.model_validate(created_subnet, from_attributes=True)
 
 
@@ -309,6 +360,7 @@ async def upload_subnet_template_endpoint(
 async def get_host_template_headers_endpoint(
     standalone_only: bool = True,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> list[TemplateHostSchema]:
     """Get a list of host template headers.
 
@@ -316,18 +368,22 @@ async def get_host_template_headers_endpoint(
     ----
         standalone_only (bool): Return only standalone host templates (not part of a range/vpc/subnet template). Defaults to True.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        list[TemplateHostID]: List of host template UUIDs.
+        list[TemplateHostID]: List of host template UUIDs owned by the current user.
 
     """
-    host_headers = await get_host_template_headers(db, standalone_only=standalone_only)
+    # Get host headers filtered by owner_id
+    host_headers = await get_host_template_headers(
+        db, standalone_only=standalone_only, user_id=current_user.id
+    )
 
     if not host_headers:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Unable to find any{" standalone" if standalone_only else ""} host templates!",
+            detail=f"Unable to find any{" standalone" if standalone_only else ""} host templates that you own!",
         )
 
     return [
@@ -338,7 +394,9 @@ async def get_host_template_headers_endpoint(
 
 @router.get("/hosts/{host_id}")
 async def get_host_template_endpoint(
-    host_id: str, db: AsyncSession = Depends(async_get_db)  # noqa: B008
+    host_id: str, 
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateHostSchema:
     """Get a host template.
 
@@ -346,10 +404,11 @@ async def get_host_template_endpoint(
     ----
         host_id (str): Id of the host.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        TemplateHostSchema: Host data from database.
+        TemplateHostSchema: Host data from database if it belongs to the user.
 
     """
     if not is_valid_uuid4(host_id):
@@ -358,12 +417,12 @@ async def get_host_template_endpoint(
             detail="ID provided is not a valid UUID4.",
         )
 
-    host_template = await get_host_template(db, TemplateHostID(id=host_id))
+    host_template = await get_host_template(db, TemplateHostID(id=host_id), user_id=current_user.id)
 
     if not host_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Host with id: {host_id} not found!",
+            detail=f"Host with id: {host_id} not found or you don't have access to it!",
         )
 
     return TemplateHostSchema.model_validate(host_template, from_attributes=True)
@@ -373,6 +432,7 @@ async def get_host_template_endpoint(
 async def upload_host_template_endpoint(
     host_template: TemplateHostBaseSchema,
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
+    current_user: UserModel = Depends(get_current_user)
 ) -> TemplateHostID:
     """Upload a host template.
 
@@ -380,11 +440,18 @@ async def upload_host_template_endpoint(
     ----
         host_template (TemplateHostBaseSchema): OpenLabs compliant host template object.
         db (AsyncSession): Async database connection.
+        current_user (UserModel): Currently authenticated user.
 
     Returns:
     -------
-        TemplateHostID: Identity of the subnet template.
+        TemplateHostID: Identity of the host template.
 
     """
-    created_host = await create_host_template(db, host_template)
-    return TemplateHostSchema.model_validate(created_host, from_attributes=True)
+    # Create host with current user as owner
+    created_host = await create_host_template(
+        db, 
+        host_template,
+        owner_id=current_user.id
+    )
+    
+    return TemplateHostID.model_validate(created_host, from_attributes=True)

--- a/src/app/api/v1/templates.py
+++ b/src/app/api/v1/templates.py
@@ -119,7 +119,7 @@ async def get_range_template_endpoint(
     if not range_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Range with id: {range_id} not found or you don't have access to it!",
+            detail=f"Range with ID: {range_id} not found or you don't have access to it!",
         )
 
     return TemplateRangeSchema.model_validate(range_template, from_attributes=True)
@@ -221,7 +221,7 @@ async def get_vpc_template_endpoint(
     if not vpc_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"VPC with id: {vpc_id} not found or you don't have access to it!",
+            detail=f"VPC with ID: {vpc_id} not found or you don't have access to it!",
         )
 
     return TemplateVPCSchema.model_validate(vpc_template, from_attributes=True)
@@ -321,7 +321,7 @@ async def get_subnet_template_endpoint(
     if not subnet_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Subnet with id: {subnet_id} not found or you don't have access to it!",
+            detail=f"Subnet with ID: {subnet_id} not found or you don't have access to it!",
         )
 
     return TemplateSubnetSchema.model_validate(subnet_template, from_attributes=True)
@@ -422,7 +422,7 @@ async def get_host_template_endpoint(
     if not host_template:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Host with id: {host_id} not found or you don't have access to it!",
+            detail=f"Host with ID: {host_id} not found or you don't have access to it!",
         )
 
     return TemplateHostSchema.model_validate(host_template, from_attributes=True)

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -1,0 +1,177 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio.session import AsyncSession
+
+from ...core.auth.auth import get_current_user
+from ...core.db.database import async_get_db
+from ...crud.crud_users import update_user_password
+from ...models.user_model import UserModel
+from ...schemas.secret_schema import AWSSecrets, AzureSecrets
+from ...schemas.user_schema import PasswordUpdateSchema, UserInfoResponseSchema
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/me", response_model=UserInfoResponseSchema)
+async def get_user_info(
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
+) -> UserInfoResponseSchema:
+    """Get the current user's information.
+
+    Args:
+    ----
+        current_user (UserModel): The authenticated user.
+
+    Returns:
+    -------
+        UserInfoResponse: User's profile information.
+
+    """
+    return UserInfoResponseSchema(name=current_user.name, email=current_user.email)
+
+
+@router.post("/me/password")
+async def update_password(
+    password_update: PasswordUpdateSchema,
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
+) -> dict[str, str]:
+    """Update the current user's password.
+
+    Args:
+    ----
+        password_update (PasswordUpdate): The current and new passwords.
+        current_user (UserModel): The authenticated user.
+        db (Session): Database connection.
+
+    Returns:
+    -------
+        dict[str, str]: Success message.
+
+    """
+    success = update_user_password(
+        db,
+        current_user.id,
+        password_update.current_password,
+        password_update.new_password,
+    )
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect",
+        )
+    return {"message": "Password updated successfully"}
+
+
+@router.get("/me/secrets")
+async def get_user_secrets(
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
+) -> dict[str, Any]:
+    """Get the current user's cloud provider secrets status.
+
+    Args:
+    ----
+        current_user (UserModel): The authenticated user.
+
+    Returns:
+    -------
+        dict: Status of user's cloud provider credentials.
+
+    """
+    # Check if the user has secrets
+    if not current_user.secrets:
+        return {
+            "aws": {"has_credentials": False},
+            "azure": {"has_credentials": False},
+        }
+
+    aws_created_at = None
+    if current_user.secrets.aws_created_at:
+        aws_created_at = current_user.secrets.aws_created_at.isoformat()
+
+    azure_created_at = None
+    if current_user.secrets.azure_created_at:
+        azure_created_at = current_user.secrets.azure_created_at.isoformat()
+
+    return {
+        "aws": {
+            "has_credentials": current_user.secrets.aws_access_key is not None,
+            "created_at": aws_created_at,
+        },
+        "azure": {
+            "has_credentials": current_user.secrets.azure_client_id is not None,
+            "created_at": azure_created_at,
+        },
+    }
+
+
+@router.post("/me/secrets/aws")
+async def update_aws_secrets(
+    aws_secrets: AWSSecrets,
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
+) -> dict[str, str]:
+    """Update the current user's AWS secrets.
+
+    Args:
+    ----
+        aws_secrets (AWSSecrets): The AWS credentials to store.
+        current_user (UserModel): The authenticated user.
+        db (Session): Database connection.
+
+    Returns:
+    -------
+        dict[str, str]: Success message.
+
+    """
+    secrets = current_user.secrets
+    if not secrets:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="User secrets record not found",
+        )
+
+    # Update the secrets
+    secrets.aws_access_key = aws_secrets.aws_access_key
+    secrets.aws_secret_key = aws_secrets.aws_secret_key
+    secrets.aws_created_at = datetime.now(UTC)
+    await db.commit()
+
+    return {"message": "AWS credentials updated successfully"}
+
+
+@router.post("/me/secrets/azure")
+async def update_azure_secrets(
+    azure_secrets: AzureSecrets,
+    current_user: UserModel = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(async_get_db),  # noqa: B008
+) -> dict[str, str]:
+    """Update the current user's Azure secrets.
+
+    Args:
+    ----
+        azure_secrets (AzureSecrets): The Azure credentials to store.
+        current_user (UserModel): The authenticated user.
+        db (Session): Database connection.
+
+    Returns:
+    -------
+        dict[str, str]: Success message.
+
+    """
+    secrets = current_user.secrets
+    if not secrets:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="User secrets record not found",
+        )
+
+    # Update the secrets
+    secrets.azure_client_id = azure_secrets.azure_client_id
+    secrets.azure_client_secret = azure_secrets.azure_client_secret
+    secrets.azure_created_at = datetime.now(UTC)
+    await db.commit()
+
+    return {"message": "Azure credentials updated successfully"}

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -1,19 +1,96 @@
-from datetime import UTC, datetime
+import base64
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio.session import AsyncSession
 
 from ...core.auth.auth import get_current_user
+from ...core.config import settings
 from ...core.db.database import async_get_db
-from ...crud.crud_users import update_user_password
+from ...crud.crud_users import get_user_by_id, update_user_password
 from ...models.secret_model import SecretModel
 from ...models.user_model import UserModel
 from ...schemas.secret_schema import AWSSecrets, AzureSecrets
-from ...schemas.user_schema import PasswordUpdateSchema, UserInfoResponseSchema
+from ...schemas.user_schema import PasswordUpdateSchema, UserID, UserInfoResponseSchema
+from ...utils.crypto import (
+    decrypt_private_key,
+    decrypt_with_private_key,
+    encrypt_with_public_key,
+    generate_master_key,
+)
 
 router = APIRouter(prefix="/users", tags=["users"])
+
+
+async def get_decrypted_secrets(
+    user: UserModel,
+    db: AsyncSession,
+    enc_key: str | None
+) -> dict[str, Any]:
+    """Get decrypted secrets for the user.
+    
+    Args:
+    ----
+        user (UserModel): The user whose secrets to decrypt
+        db (AsyncSession): Database connection
+        enc_key (str | None): Base64-encoded encryption key from cookie
+        
+    Returns:
+    -------
+        dict: Decrypted secrets or None if decryption fails
+
+    """
+    if not enc_key or not user.encrypted_private_key:
+        return None
+
+    # Fetch the user's secrets from the database
+    stmt = select(SecretModel).where(SecretModel.user_id == user.id)
+    result = await db.execute(stmt)
+    secrets = result.scalars().first()
+
+    if not secrets:
+        return None
+
+    try:
+        # Decode the encryption key
+        master_key = base64.b64decode(enc_key)
+
+        # Decrypt the private key
+        private_key_b64 = decrypt_private_key(user.encrypted_private_key, master_key)
+
+        # Prepare containers for decrypted secrets
+        aws_secrets = None
+        azure_secrets = None
+
+        # Decrypt AWS secrets if they exist
+        if secrets.aws_access_key and secrets.aws_secret_key:
+            encrypted_aws = {
+                "aws_access_key": secrets.aws_access_key,
+                "aws_secret_key": secrets.aws_secret_key,
+            }
+            aws_secrets = decrypt_with_private_key(encrypted_aws, private_key_b64)
+
+        # Decrypt Azure secrets if they exist
+        if (secrets.azure_client_id and secrets.azure_client_secret and
+            secrets.azure_tenant_id and secrets.azure_subscription_id):
+            encrypted_azure = {
+                "azure_client_id": secrets.azure_client_id,
+                "azure_client_secret": secrets.azure_client_secret,
+                "azure_tenant_id": secrets.azure_tenant_id,
+                "azure_subscription_id": secrets.azure_subscription_id,
+            }
+            azure_secrets = decrypt_with_private_key(encrypted_azure, private_key_b64)
+
+        return {
+            "aws": aws_secrets,
+            "azure": azure_secrets
+        }
+    except Exception:
+        # If decryption fails, return None
+        return None
 
 
 @router.get("/me", response_model=UserInfoResponseSchema)
@@ -41,7 +118,7 @@ async def update_password(
     password_update: PasswordUpdateSchema,
     current_user: UserModel = Depends(get_current_user),  # noqa: B008
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
-) -> dict[str, str]:
+) -> JSONResponse:
     """Update the current user's password.
 
     Args:
@@ -52,7 +129,7 @@ async def update_password(
 
     Returns:
     -------
-        dict[str, str]: Success message.
+        JSONResponse: Success message with updated cookie.
 
     """
     success = await update_user_password(
@@ -66,7 +143,36 @@ async def update_password(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Current password is incorrect",
         )
-    return {"message": "Password updated successfully"}
+
+    # Get the updated user to access the new salt
+    updated_user = await get_user_by_id(db, UserID(id=current_user.id))
+    if not updated_user or not updated_user.key_salt:
+        # This should not happen, but handle the case anyway
+        return JSONResponse(content={"message": "Password updated successfully"})
+
+    # Generate a new master key with the new password and updated salt
+    master_key, _ = generate_master_key(password_update.new_password, updated_user.key_salt)
+    master_key_b64 = base64.b64encode(master_key).decode("utf-8")
+
+    # Set expiry time to match the authentication token
+    expire = datetime.now(UTC) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire_seconds = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+
+    # Create the response with updated cookie
+    response = JSONResponse(content={"message": "Password updated successfully"})
+
+    # Set the new encryption key cookie
+    response.set_cookie(
+        key="enc_key",
+        value=master_key_b64,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=expire_seconds,
+        path="/",
+    )
+
+    return response
 
 
 @router.get("/me/secrets")
@@ -150,9 +256,25 @@ async def update_aws_secrets(
             detail="User secrets record not found",
         )
 
-    # Update the secrets
-    secrets.aws_access_key = aws_secrets.aws_access_key
-    secrets.aws_secret_key = aws_secrets.aws_secret_key
+    # Encrypt the AWS credentials using the user's public key
+    if not current_user.public_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User encryption keys not set up. Please register a new account.",
+        )
+
+    # Convert to dictionary for encryption
+    aws_data = {
+        "aws_access_key": aws_secrets.aws_access_key,
+        "aws_secret_key": aws_secrets.aws_secret_key,
+    }
+
+    # Encrypt with the user's public key
+    encrypted_data = encrypt_with_public_key(aws_data, current_user.public_key)
+
+    # Update the secrets with encrypted values
+    secrets.aws_access_key = encrypted_data["aws_access_key"]
+    secrets.aws_secret_key = encrypted_data["aws_secret_key"]
     secrets.aws_created_at = datetime.now(UTC)
     await db.commit()
 
@@ -188,11 +310,29 @@ async def update_azure_secrets(
             detail="User secrets record not found",
         )
 
-    # Update the secrets
-    secrets.azure_client_id = azure_secrets.azure_client_id
-    secrets.azure_client_secret = azure_secrets.azure_client_secret
-    secrets.azure_tenant_id = azure_secrets.azure_tenant_id
-    secrets.azure_subscription_id = azure_secrets.azure_subscription_id
+    # Encrypt the Azure credentials using the user's public key
+    if not current_user.public_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User encryption keys not set up. Please register a new account.",
+        )
+
+    # Convert to dictionary for encryption
+    azure_data = {
+        "azure_client_id": azure_secrets.azure_client_id,
+        "azure_client_secret": azure_secrets.azure_client_secret,
+        "azure_tenant_id": azure_secrets.azure_tenant_id,
+        "azure_subscription_id": azure_secrets.azure_subscription_id,
+    }
+
+    # Encrypt with the user's public key
+    encrypted_data = encrypt_with_public_key(azure_data, current_user.public_key)
+
+    # Update the secrets with encrypted values
+    secrets.azure_client_id = encrypted_data["azure_client_id"]
+    secrets.azure_client_secret = encrypted_data["azure_client_secret"]
+    secrets.azure_tenant_id = encrypted_data["azure_tenant_id"]
+    secrets.azure_subscription_id = encrypted_data["azure_subscription_id"]
     secrets.azure_created_at = datetime.now(UTC)
     await db.commit()
 

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -111,10 +111,10 @@ async def get_user_secrets(
         },
         "azure": {
             "has_credentials": (
-                secrets.azure_client_id is not None and
-                secrets.azure_client_secret is not None and
-                secrets.azure_tenant_id is not None and
-                secrets.azure_subscription_id is not None
+                secrets.azure_client_id is not None
+                and secrets.azure_client_secret is not None
+                and secrets.azure_tenant_id is not None
+                and secrets.azure_subscription_id is not None
             ),
             "created_at": azure_created_at,
         },

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -110,7 +110,12 @@ async def get_user_secrets(
             "created_at": aws_created_at,
         },
         "azure": {
-            "has_credentials": secrets.azure_client_id is not None,
+            "has_credentials": (
+                secrets.azure_client_id is not None and
+                secrets.azure_client_secret is not None and
+                secrets.azure_tenant_id is not None and
+                secrets.azure_subscription_id is not None
+            ),
             "created_at": azure_created_at,
         },
     }
@@ -186,6 +191,8 @@ async def update_azure_secrets(
     # Update the secrets
     secrets.azure_client_id = azure_secrets.azure_client_id
     secrets.azure_client_secret = azure_secrets.azure_client_secret
+    secrets.azure_tenant_id = azure_secrets.azure_tenant_id
+    secrets.azure_subscription_id = azure_secrets.azure_subscription_id
     secrets.azure_created_at = datetime.now(UTC)
     await db.commit()
 

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -133,7 +133,10 @@ async def update_aws_secrets(
         dict[str, str]: Success message.
 
     """
-    secrets = current_user.secrets
+    # Fetch secrets explicitly from the database
+    stmt = select(SecretModel).where(SecretModel.user_id == current_user.id)
+    result = await db.execute(stmt)
+    secrets = result.scalars().first()
     if not secrets:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -168,7 +171,10 @@ async def update_azure_secrets(
         dict[str, str]: Success message.
 
     """
-    secrets = current_user.secrets
+    # Fetch secrets explicitly from the database
+    stmt = select(SecretModel).where(SecretModel.user_id == current_user.id)
+    result = await db.execute(stmt)
+    secrets = result.scalars().first()
     if not secrets:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -31,7 +31,9 @@ async def get_user_info(
         UserInfoResponse: User's profile information.
 
     """
-    return UserInfoResponseSchema(name=current_user.name, email=current_user.email)
+    return UserInfoResponseSchema(
+        name=current_user.name, email=current_user.email, admin=current_user.is_admin
+    )
 
 
 @router.post("/me/password")

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -51,7 +51,7 @@ async def update_password(
         dict[str, str]: Success message.
 
     """
-    success = update_user_password(
+    success = await update_user_password(
         db,
         current_user.id,
         password_update.current_password,

--- a/src/app/core/__init__.py
+++ b/src/app/core/__init__.py
@@ -1,1 +1,1 @@
-"""Core app logic of the OpenLabsX API."""
+"""Core app logic of the OpenLabs API."""

--- a/src/app/core/auth/__init__.py
+++ b/src/app/core/auth/__init__.py
@@ -1,1 +1,1 @@
-"""Core authentication logic of the OpenLabsX API."""
+"""Core authentication logic of the OpenLabs API."""

--- a/src/app/core/auth/__init__.py
+++ b/src/app/core/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Core authentication logic of the OpenLabsX API."""

--- a/src/app/core/auth/auth.py
+++ b/src/app/core/auth/auth.py
@@ -17,7 +17,7 @@ security = HTTPBearer(auto_error=False)
 
 async def get_current_user(
     request: Request,
-    token: str | None = Cookie(None, alias="token"),
+    token: str | None = Cookie(None, alias="token", include_in_schema=False),
     credentials: HTTPAuthorizationCredentials | None = Depends(security),  # noqa: B008
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
 ) -> UserModel:

--- a/src/app/core/auth/auth.py
+++ b/src/app/core/auth/auth.py
@@ -1,0 +1,117 @@
+from datetime import datetime, timedelta, UTC
+from typing import Optional
+
+import jwt
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..config import settings
+from ..db.database import async_get_db
+from ...crud.crud_users import get_user_by_id
+from ...models.user_model import UserModel
+from ...schemas.user_schema import UserID
+
+
+# Create a security scheme using HTTPBearer
+security = HTTPBearer()
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: AsyncSession = Depends(async_get_db),
+) -> UserModel:
+    """Get the current user from the JWT token.
+
+    Args:
+    ----
+        credentials (HTTPAuthorizationCredentials): HTTP Bearer token
+        db (AsyncSession): Database connection
+
+    Returns:
+    -------
+        UserModel: The current authenticated user
+
+    Raises:
+    ------
+        HTTPException: If the token is invalid or the user doesn't exist
+    """
+    try:
+        # Decode the JWT token
+        payload = jwt.decode(
+            credentials.credentials,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM]
+        )
+        
+        # Get the user ID from the token
+        user_id = payload.get("user")
+        
+        if user_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication credentials",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        
+        # Get the expiration time from the token
+        expiration = payload.get("exp")
+        if expiration is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token has no expiration",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        
+        # Check if the token has expired
+        if datetime.now(UTC) > datetime.fromtimestamp(expiration, tz=UTC):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token has expired",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            
+        # Get the user from the database
+        user = await get_user_by_id(db, UserID(id=user_id))
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="User not found",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        
+        # Update the last_active field - remove timezone to match DB schema
+        now = datetime.now(UTC)
+        user.last_active = now.replace(tzinfo=None)
+        await db.commit()
+        
+        return user
+        
+    except jwt.PyJWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def is_admin(user: UserModel = Depends(get_current_user)) -> UserModel:
+    """Check if the user is an admin.
+
+    Args:
+    ----
+        user (UserModel): The authenticated user
+
+    Returns:
+    -------
+        UserModel: The authenticated user if they are an admin
+
+    Raises:
+    ------
+        HTTPException: If the user is not an admin
+    """
+    if not user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not enough permissions",
+        )
+    return user

--- a/src/app/core/auth/auth.py
+++ b/src/app/core/auth/auth.py
@@ -14,8 +14,9 @@ from ..db.database import async_get_db
 # Create a security scheme using HTTPBearer
 security = HTTPBearer()
 
+
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security), # noqa: B008
+    credentials: HTTPAuthorizationCredentials = Depends(security),  # noqa: B008
     db: AsyncSession = Depends(async_get_db),  # noqa: B008
 ) -> UserModel:
     """Get the current user from the JWT token.
@@ -39,7 +40,7 @@ async def get_current_user(
         payload = jwt.decode(
             credentials.credentials,
             settings.SECRET_KEY,
-            algorithms=[settings.ALGORITHM]
+            algorithms=[settings.ALGORITHM],
         )
 
         # Get the user ID from the token
@@ -93,8 +94,7 @@ async def get_current_user(
         ) from e
 
 
-def is_admin(user: UserModel = Depends(get_current_user) # noqa: B008
-             ) -> UserModel:
+def is_admin(user: UserModel = Depends(get_current_user)) -> UserModel:  # noqa: B008
     """Check if the user is an admin.
 
     Args:

--- a/src/app/core/cdktf/__init__.py
+++ b/src/app/core/cdktf/__init__.py
@@ -1,1 +1,1 @@
-"""CDKTF logic for the OpenLabsX API."""
+"""CDKTF logic for the OpenLabs API."""

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -24,7 +24,7 @@ class AppSettings(BaseSettings):
     LICENSE_NAME: str | None = config("LICENSE", default="GPLv3")
     LICENSE_URL: str | None = config(
         "LICENSE_URL",
-        default="https://github.com/OpenLabs/API?tab=GPL-3.0-1-ov-file#readme",
+        default="https://github.com/OpenLabsHQ/API?tab=GPL-3.0-1-ov-file#readme",
     )
     CONTACT_NAME: str | None = config("CONTACT_NAME", default="OpenLabs Support")
     CONTACT_EMAIL: str | None = config("CONTACT_EMAIL", default="support@openlabs.sh")

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -38,7 +38,7 @@ class AuthSettings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = config(
         "ACCESS_TOKEN_EXPIRE_MINUTES", default=60 * 24 * 7
     )  # One week
-    
+
     # Admin user settings
     ADMIN_EMAIL: str = config("ADMIN_EMAIL", default="admin@test.com")
     ADMIN_PASSWORD: str = config("ADMIN_PASSWORD", default="admin123")

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 
 from pydantic_settings import BaseSettings
 from setuptools_scm import get_version
@@ -28,6 +29,14 @@ class AppSettings(BaseSettings):
     )
     CONTACT_NAME: str | None = config("CONTACT_NAME", default="OpenLabsX Support")
     CONTACT_EMAIL: str | None = config("CONTACT_EMAIL", default="support@openlabsx.com")
+
+
+class AuthSettings(BaseSettings):
+    """Authentication settings."""
+
+    SECRET_KEY: str = config("SECRET_KEY")
+    ALGORITHM: str = config("ALGORITHM", default="HS256")
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = config("ACCESS_TOKEN_EXPIRE_MINUTES", default=60 * 24 * 7)  # One week
 
 
 class CDKTFSettings(BaseSettings):
@@ -60,7 +69,7 @@ class PostgresSettings(DatabaseSettings):
     POSTGRES_URL: str | None = config("POSTGRES_URL", default=None)
 
 
-class Settings(AppSettings, PostgresSettings, CDKTFSettings):
+class Settings(AppSettings, PostgresSettings, CDKTFSettings, AuthSettings):
     """FastAPI app settings."""
 
     pass

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -14,9 +14,9 @@ config = Config(env_path)
 class AppSettings(BaseSettings):
     """FastAPI app settings."""
 
-    APP_NAME: str = config("APP_NAME", default="OpenLabsX API")
+    APP_NAME: str = config("APP_NAME", default="OpenLabs API")
     APP_DESCRIPTION: str | None = config(
-        "APP_DESCRIPTION", default="OpenLabsX backend API."
+        "APP_DESCRIPTION", default="OpenLabs backend API."
     )
     APP_VERSION: str | None = config(
         "APP_VERSION", default=get_version()
@@ -24,9 +24,9 @@ class AppSettings(BaseSettings):
     LICENSE_NAME: str | None = config("LICENSE", default="GPLv3")
     LICENSE_URL: str | None = config(
         "LICENSE_URL",
-        default="https://github.com/OpenLabsX/API?tab=GPL-3.0-1-ov-file#readme",
+        default="https://github.com/OpenLabs/API?tab=GPL-3.0-1-ov-file#readme",
     )
-    CONTACT_NAME: str | None = config("CONTACT_NAME", default="OpenLabsX Support")
+    CONTACT_NAME: str | None = config("CONTACT_NAME", default="OpenLabs Support")
     CONTACT_EMAIL: str | None = config("CONTACT_EMAIL", default="support@openlabsx.com")
 
 

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -35,7 +35,9 @@ class AuthSettings(BaseSettings):
 
     SECRET_KEY: str = config("SECRET_KEY")
     ALGORITHM: str = config("ALGORITHM", default="HS256")
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = config("ACCESS_TOKEN_EXPIRE_MINUTES", default=60 * 24 * 7)  # One week
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = config(
+        "ACCESS_TOKEN_EXPIRE_MINUTES", default=60 * 24 * 7
+    )  # One week
 
 
 class CDKTFSettings(BaseSettings):

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -27,7 +27,7 @@ class AppSettings(BaseSettings):
         default="https://github.com/OpenLabs/API?tab=GPL-3.0-1-ov-file#readme",
     )
     CONTACT_NAME: str | None = config("CONTACT_NAME", default="OpenLabs Support")
-    CONTACT_EMAIL: str | None = config("CONTACT_EMAIL", default="support@openlabsx.com")
+    CONTACT_EMAIL: str | None = config("CONTACT_EMAIL", default="support@openlabs.sh")
 
 
 class AuthSettings(BaseSettings):
@@ -38,6 +38,11 @@ class AuthSettings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = config(
         "ACCESS_TOKEN_EXPIRE_MINUTES", default=60 * 24 * 7
     )  # One week
+    
+    # Admin user settings
+    ADMIN_EMAIL: str = config("ADMIN_EMAIL", default="admin@test.com")
+    ADMIN_PASSWORD: str = config("ADMIN_PASSWORD", default="admin123")
+    ADMIN_NAME: str = config("ADMIN_NAME", default="Administrator")
 
 
 class CDKTFSettings(BaseSettings):

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -33,7 +33,7 @@ class AppSettings(BaseSettings):
 class AuthSettings(BaseSettings):
     """Authentication settings."""
 
-    SECRET_KEY: str = config("SECRET_KEY")
+    SECRET_KEY: str = config("SECRET_KEY", default="ChangeMe123!")
     ALGORITHM: str = config("ALGORITHM", default="HS256")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = config(
         "ACCESS_TOKEN_EXPIRE_MINUTES", default=60 * 24 * 7

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -1,5 +1,4 @@
 import os
-from datetime import timedelta
 
 from pydantic_settings import BaseSettings
 from setuptools_scm import get_version

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -48,7 +48,9 @@ async def initialize_admin_user() -> None:
                 master_key, key_salt = generate_master_key(settings.ADMIN_PASSWORD)
 
                 # Encrypt the private key with the master key
-                encrypted_private_key_b64 = encrypt_private_key(private_key_b64, master_key)
+                encrypted_private_key_b64 = encrypt_private_key(
+                    private_key_b64, master_key
+                )
 
                 # Update the user with encryption keys
                 admin_user.public_key = public_key_b64

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -3,7 +3,7 @@ from typing import Any, AsyncContextManager, AsyncGenerator, Callable
 
 from fastapi import APIRouter, FastAPI
 
-from ..crud.crud_users import create_user
+from ..crud.crud_users import create_user, get_user
 from ..schemas.user_schema import UserCreateBaseSchema
 from .config import AppSettings, DatabaseSettings, settings
 from .db.database import Base, local_session
@@ -29,8 +29,9 @@ async def initialize_admin_user() -> None:
                 name=settings.ADMIN_NAME,
             )
 
-            # Create the admin user
-            await create_user(db, admin_schema, is_admin=True)
+            admin_user = await get_user(db, settings.ADMIN_EMAIL)
+            if not admin_user:
+                await create_user(db, admin_schema, is_admin=True)
     except Exception as e:
         msg = "Failed to create admin user. Check logs for more details."
         raise ValueError(msg) from e

--- a/src/app/crud/crud_host_templates.py
+++ b/src/app/crud/crud_host_templates.py
@@ -13,7 +13,7 @@ from ..schemas.template_subnet_schema import TemplateSubnetID
 import uuid
 
 async def get_host_template_headers(
-    db: AsyncSession, standalone_only: bool = True, user_id: uuid.UUID = None
+    db: AsyncSession, standalone_only: bool = True, user_id: uuid.UUID | None = None
 ) -> list[TemplateHostModel]:
     """Get list of host template headers.
 
@@ -49,7 +49,7 @@ async def get_host_template_headers(
 
 
 async def get_host_template(
-    db: AsyncSession, host_id: TemplateHostID, user_id: uuid.UUID = None
+    db: AsyncSession, host_id: TemplateHostID, user_id: uuid.UUID | None = None
 ) -> TemplateHostModel | None:
     """Get host template by ID.
 
@@ -77,7 +77,7 @@ async def create_host_template(
     db: AsyncSession,
     template_host: TemplateHostBaseSchema,
     subnet_id: TemplateSubnetID | None = None,
-    owner_id: uuid.UUID = None,
+    owner_id: uuid.UUID | None = None,
 ) -> TemplateHostModel:
     """Create and add a new host template to the database.
 

--- a/src/app/crud/crud_host_templates.py
+++ b/src/app/crud/crud_host_templates.py
@@ -10,10 +10,10 @@ from ..schemas.template_host_schema import (
     TemplateHostSchema,
 )
 from ..schemas.template_subnet_schema import TemplateSubnetID
-
+import uuid
 
 async def get_host_template_headers(
-    db: AsyncSession, standalone_only: bool = True
+    db: AsyncSession, standalone_only: bool = True, user_id: uuid.UUID = None
 ) -> list[TemplateHostModel]:
     """Get list of host template headers.
 
@@ -22,6 +22,7 @@ async def get_host_template_headers(
         db (Session): Database connection.
         standalone_only (bool): Include only hosts that are standalone templates
             (i.e. those with a null subnet_id). Defaults to True.
+        user_id (Optional[uuid.UUID]): If provided, only return templates owned by this user.
 
     Returns:
     -------
@@ -33,22 +34,22 @@ async def get_host_template_headers(
         getattr(TemplateHostModel, attr.key) for attr in mapped_host_model.column_attrs
     ]
 
-    # Build the query: filter for rows where subnet_id is null if standalone_only is True
+    stmt = select(TemplateHostModel)
+
     if standalone_only:
-        stmt = (
-            select(TemplateHostModel)
-            .where(TemplateHostModel.subnet_id.is_(None))
-            .options(load_only(*main_columns))
-        )
-    else:
-        stmt = select(TemplateHostModel).options(load_only(*main_columns))
+        stmt = stmt.where(TemplateHostModel.subnet_id.is_(None))
+    
+    if user_id:
+        stmt = stmt.filter(TemplateHostModel.owner_id == user_id)
+    
+    stmt = stmt.options(load_only(*main_columns))
 
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
 
 async def get_host_template(
-    db: AsyncSession, host_id: TemplateHostID
+    db: AsyncSession, host_id: TemplateHostID, user_id: uuid.UUID = None
 ) -> TemplateHostModel | None:
     """Get host template by ID.
 
@@ -56,6 +57,7 @@ async def get_host_template(
     ----
         db (Sessions): Database connection.
         host_id (TemplateHostID): ID of the host.
+        user_id (Optional[uuid.UUID]): If provided, only return templates owned by this user.
 
     Returns:
     -------
@@ -63,6 +65,10 @@ async def get_host_template(
 
     """
     stmt = select(TemplateHostModel).filter(TemplateHostModel.id == host_id.id)
+    
+    if user_id:
+        stmt = stmt.filter(TemplateHostModel.owner_id == user_id)
+        
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
@@ -71,14 +77,16 @@ async def create_host_template(
     db: AsyncSession,
     template_host: TemplateHostBaseSchema,
     subnet_id: TemplateSubnetID | None = None,
+    owner_id: uuid.UUID = None,
 ) -> TemplateHostModel:
-    """Create and add a new host tempalte to the database.
+    """Create and add a new host template to the database.
 
     Args:
     ----
         db (Session): Database connection.
         template_host (TemplateHostBaseSchema): Dictionary containing host data.
-        subnet_id (Optional[str]): Subnet ID to link VPC back too.
+        subnet_id (Optional[TemplateSubnetID]): Subnet ID to link host back to.
+        owner_id (Optional[uuid.UUID]): ID of the user who owns this template.
 
     Returns:
     -------
@@ -89,6 +97,9 @@ async def create_host_template(
     host_dict = template_host.model_dump()
     if subnet_id:
         host_dict["subnet_id"] = subnet_id.id
+        
+    if owner_id:
+        host_dict["owner_id"] = owner_id
 
     host_obj = TemplateHostModel(**host_dict)
     db.add(host_obj)

--- a/src/app/crud/crud_host_templates.py
+++ b/src/app/crud/crud_host_templates.py
@@ -1,5 +1,5 @@
-import uuid
 import logging
+import uuid
 
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/app/crud/crud_host_templates.py
+++ b/src/app/crud/crud_host_templates.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -10,7 +12,7 @@ from ..schemas.template_host_schema import (
     TemplateHostSchema,
 )
 from ..schemas.template_subnet_schema import TemplateSubnetID
-import uuid
+
 
 async def get_host_template_headers(
     db: AsyncSession, standalone_only: bool = True, user_id: uuid.UUID | None = None
@@ -38,10 +40,10 @@ async def get_host_template_headers(
 
     if standalone_only:
         stmt = stmt.where(TemplateHostModel.subnet_id.is_(None))
-    
+
     if user_id:
         stmt = stmt.filter(TemplateHostModel.owner_id == user_id)
-    
+
     stmt = stmt.options(load_only(*main_columns))
 
     result = await db.execute(stmt)
@@ -65,10 +67,10 @@ async def get_host_template(
 
     """
     stmt = select(TemplateHostModel).filter(TemplateHostModel.id == host_id.id)
-    
+
     if user_id:
         stmt = stmt.filter(TemplateHostModel.owner_id == user_id)
-        
+
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
@@ -97,7 +99,7 @@ async def create_host_template(
     host_dict = template_host.model_dump()
     if subnet_id:
         host_dict["subnet_id"] = subnet_id.id
-        
+
     if owner_id:
         host_dict["owner_id"] = owner_id
 

--- a/src/app/crud/crud_range_templates.py
+++ b/src/app/crud/crud_range_templates.py
@@ -16,7 +16,7 @@ from .crud_vpc_templates import create_vpc_template
 
 
 async def get_range_template_headers(
-    db: AsyncSession, user_id: uuid.UUID = None
+    db: AsyncSession, user_id: uuid.UUID | None = None
 ) -> list[TemplateRangeModel]:
     """Get list of range template headers.
 
@@ -47,7 +47,7 @@ async def get_range_template_headers(
 
 
 async def get_range_template(
-    db: AsyncSession, range_id: TemplateRangeID, user_id: uuid.UUID = None
+    db: AsyncSession, range_id: TemplateRangeID, user_id: uuid.UUID | None = None
 ) -> TemplateRangeModel | None:
     """Get range template by id (uuid).
 

--- a/src/app/crud/crud_range_templates.py
+++ b/src/app/crud/crud_range_templates.py
@@ -1,5 +1,5 @@
-import uuid
 import logging
+import uuid
 
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio.session import AsyncSession

--- a/src/app/crud/crud_range_templates.py
+++ b/src/app/crud/crud_range_templates.py
@@ -1,8 +1,9 @@
+import uuid
+
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio.session import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import load_only, selectinload
-import uuid
 
 from ..models.template_range_model import TemplateRangeModel
 from ..models.template_subnet_model import TemplateSubnetModel
@@ -38,10 +39,10 @@ async def get_range_template_headers(
     ]
 
     stmt = select(TemplateRangeModel).options(load_only(*main_columns))
-    
+
     if user_id:
         stmt = stmt.filter(TemplateRangeModel.owner_id == user_id)
-        
+
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
@@ -72,15 +73,14 @@ async def get_range_template(
         )
         .filter(TemplateRangeModel.id == range_id.id)
     )
-    
+
     if user_id:
         stmt = stmt.filter(TemplateRangeModel.owner_id == user_id)
-        
+
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
 
-# TODO: Later, we can allow anyone to deploy a range if they own it or if they can read it
 async def is_range_template_owner(
     db: AsyncSession, range_id: TemplateRangeID, user_id: uuid.UUID
 ) -> bool:
@@ -95,6 +95,7 @@ async def is_range_template_owner(
     Returns:
     -------
         bool: True if the user is the owner, False otherwise.
+
     """
     stmt = (
         select(TemplateRangeModel)
@@ -123,7 +124,7 @@ async def create_range_template(
     """
     range_template = TemplateRangeSchema(**range_template.model_dump())
     range_dict = range_template.model_dump(exclude={"vpcs"})
-    
+
     range_dict["owner_id"] = owner_id
 
     # Create the Range object (No commit yet)

--- a/src/app/crud/crud_subnet_templates.py
+++ b/src/app/crud/crud_subnet_templates.py
@@ -120,7 +120,7 @@ async def create_subnet_template(
             db,
             host_data,
             TemplateSubnetID(id=subnet_obj.id),
-            owner_id=owner_id  # Pass owner_id to hosts
+            owner_id=owner_id,  # Pass owner_id to hosts
         )
         for host_data in template_subnet.hosts
     ]

--- a/src/app/crud/crud_subnet_templates.py
+++ b/src/app/crud/crud_subnet_templates.py
@@ -14,7 +14,7 @@ from .crud_host_templates import create_host_template
 import uuid
 
 async def get_subnet_template_headers(
-    db: AsyncSession, standalone_only: bool = True, user_id: uuid.UUID = None
+    db: AsyncSession, standalone_only: bool = True, user_id: uuid.UUID | None = None
 ) -> list[TemplateSubnetModel]:
     """Get list of subnet template headers.
 
@@ -53,7 +53,7 @@ async def get_subnet_template_headers(
 
 
 async def get_subnet_template(
-    db: AsyncSession, subnet_id: TemplateSubnetID, user_id: uuid.UUID = None
+    db: AsyncSession, subnet_id: TemplateSubnetID, user_id: uuid.UUID | None = None
 ) -> TemplateSubnetModel | None:
     """Get subnet template by id (uuid).
 
@@ -85,7 +85,7 @@ async def create_subnet_template(
     db: AsyncSession,
     template_subnet: TemplateSubnetBaseSchema,
     vpc_id: TemplateVPCID | None = None,
-    owner_id: uuid.UUID = None,
+    owner_id: uuid.UUID | None = None,
 ) -> TemplateSubnetModel:
     """Create and add a new subnet template to the database.
 

--- a/src/app/crud/crud_subnet_templates.py
+++ b/src/app/crud/crud_subnet_templates.py
@@ -1,5 +1,5 @@
-import uuid
 import logging
+import uuid
 
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/app/crud/crud_subnet_templates.py
+++ b/src/app/crud/crud_subnet_templates.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -11,7 +13,7 @@ from ..schemas.template_subnet_schema import (
 )
 from ..schemas.template_vpc_schema import TemplateVPCID
 from .crud_host_templates import create_host_template
-import uuid
+
 
 async def get_subnet_template_headers(
     db: AsyncSession, standalone_only: bool = True, user_id: uuid.UUID | None = None
@@ -39,13 +41,13 @@ async def get_subnet_template_headers(
 
     # Start building the query
     stmt = select(TemplateSubnetModel)
-    
+
     if standalone_only:
         stmt = stmt.where(TemplateSubnetModel.vpc_id.is_(None))
-    
+
     if user_id:
         stmt = stmt.filter(TemplateSubnetModel.owner_id == user_id)
-    
+
     stmt = stmt.options(load_only(*main_columns))
 
     result = await db.execute(stmt)
@@ -73,10 +75,10 @@ async def get_subnet_template(
         .options(selectinload(TemplateSubnetModel.hosts))
         .filter(TemplateSubnetModel.id == subnet_id.id)
     )
-    
+
     if user_id:
         stmt = stmt.filter(TemplateSubnetModel.owner_id == user_id)
-        
+
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
@@ -105,7 +107,7 @@ async def create_subnet_template(
     subnet_dict = template_subnet.model_dump(exclude={"hosts"})
     if vpc_id:
         subnet_dict["vpc_id"] = vpc_id.id
-        
+
     if owner_id:
         subnet_dict["owner_id"] = owner_id
 
@@ -115,8 +117,8 @@ async def create_subnet_template(
     # Add hosts
     host_objects = [
         await create_host_template(
-            db, 
-            host_data, 
+            db,
+            host_data,
             TemplateSubnetID(id=subnet_obj.id),
             owner_id=owner_id  # Pass owner_id to hosts
         )

--- a/src/app/crud/crud_users.py
+++ b/src/app/crud/crud_users.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from typing import Any, Dict
 from uuid import UUID
 
 from bcrypt import checkpw, gensalt, hashpw
@@ -13,6 +14,13 @@ from ..schemas.user_schema import (
     UserCreateBaseSchema,
     UserCreateSchema,
     UserID,
+)
+from ..utils.crypto import (
+    decrypt_private_key,
+    decrypt_with_private_key,
+    encrypt_private_key,
+    generate_master_key,
+    generate_rsa_key_pair,
 )
 
 
@@ -119,12 +127,26 @@ async def create_user(
     user_dict = openlabs_user.model_dump(exclude={"secrets"})
 
     # Here, we populate fields to match the database model
-    del user_dict["password"]
+    password = user_dict.pop("password")
 
+    # Generate bcrypt password hash
     hash_salt = gensalt()
-    hashed_password = hashpw(openlabs_user.password.encode(), hash_salt)
-
+    hashed_password = hashpw(password.encode(), hash_salt)
     user_dict["hashed_password"] = hashed_password.decode()
+
+    # Generate RSA key pair
+    private_key_b64, public_key_b64 = generate_rsa_key_pair()
+
+    # Generate master key from password using Argon2
+    master_key, key_salt = generate_master_key(password)
+
+    # Encrypt the private key with the master key
+    encrypted_private_key_b64 = encrypt_private_key(private_key_b64, master_key)
+
+    # Store public key, encrypted private key and salt in user record
+    user_dict["public_key"] = public_key_b64
+    user_dict["encrypted_private_key"] = encrypted_private_key_b64
+    user_dict["key_salt"] = key_salt
 
     user_dict["created_at"] = datetime.now(UTC)
     user_dict["last_active"] = datetime.now(UTC)
@@ -145,6 +167,71 @@ async def create_user(
     await db.commit()
 
     return user_obj
+
+
+async def get_decrypted_secrets(
+    user: UserModel,
+    db: AsyncSession,
+    master_key: bytes
+) -> Dict[str, Any] | None:
+    """Get decrypted secrets for the user.
+    
+    Args:
+    ----
+        user (UserModel): The user whose secrets to decrypt
+        db (AsyncSession): Database connection
+        master_key (bytes): The decryption master key
+        
+    Returns:
+    -------
+        Dict | None: Decrypted secrets or None if decryption fails
+
+    """
+    if not master_key or not user.encrypted_private_key:
+        return None
+
+    # Fetch the user's secrets from the database
+    stmt = select(SecretModel).where(SecretModel.user_id == user.id)
+    result = await db.execute(stmt)
+    secrets = result.scalars().first()
+
+    if not secrets:
+        return None
+
+    try:
+        # Decrypt the private key
+        private_key_b64 = decrypt_private_key(user.encrypted_private_key, master_key)
+
+        # Prepare containers for decrypted secrets
+        aws_secrets = None
+        azure_secrets = None
+
+        # Decrypt AWS secrets if they exist
+        if secrets.aws_access_key and secrets.aws_secret_key:
+            encrypted_aws = {
+                "aws_access_key": secrets.aws_access_key,
+                "aws_secret_key": secrets.aws_secret_key,
+            }
+            aws_secrets = decrypt_with_private_key(encrypted_aws, private_key_b64)
+
+        # Decrypt Azure secrets if they exist
+        if (secrets.azure_client_id and secrets.azure_client_secret and
+            secrets.azure_tenant_id and secrets.azure_subscription_id):
+            encrypted_azure = {
+                "azure_client_id": secrets.azure_client_id,
+                "azure_client_secret": secrets.azure_client_secret,
+                "azure_tenant_id": secrets.azure_tenant_id,
+                "azure_subscription_id": secrets.azure_subscription_id,
+            }
+            azure_secrets = decrypt_with_private_key(encrypted_azure, private_key_b64)
+
+        return {
+            "aws": aws_secrets,
+            "azure": azure_secrets
+        }
+    except Exception:
+        # If decryption fails, return None
+        return None
 
 
 async def update_user_password(
@@ -179,6 +266,28 @@ async def update_user_password(
     # Hash the new password
     hash_salt = gensalt()
     hashed_password = hashpw(new_password.encode(), hash_salt)
+
+    # We need to decrypt the private key with the old master key and re-encrypt it with the new one
+    if user.encrypted_private_key and user.key_salt:
+        # Generate the old master key using the current password and stored salt
+        old_master_key, _ = generate_master_key(current_password, user.key_salt)
+
+        # Decrypt the private key using the old master key
+        try:
+            private_key_b64 = decrypt_private_key(user.encrypted_private_key, old_master_key)
+
+            # Generate a new master key and salt
+            new_master_key, new_key_salt = generate_master_key(new_password)
+
+            # Re-encrypt the private key with the new master key
+            new_encrypted_private_key = encrypt_private_key(private_key_b64, new_master_key)
+
+            # Update the user's encrypted private key and salt
+            user.encrypted_private_key = new_encrypted_private_key
+            user.key_salt = new_key_salt
+        except Exception:
+            # If decryption fails, don't update the password
+            return False
 
     # Update the user's password
     user.hashed_password = hashed_password.decode()

--- a/src/app/crud/crud_users.py
+++ b/src/app/crud/crud_users.py
@@ -170,18 +170,16 @@ async def create_user(
 
 
 async def get_decrypted_secrets(
-    user: UserModel,
-    db: AsyncSession,
-    master_key: bytes
+    user: UserModel, db: AsyncSession, master_key: bytes
 ) -> Dict[str, Any] | None:
     """Get decrypted secrets for the user.
-    
+
     Args:
     ----
         user (UserModel): The user whose secrets to decrypt
         db (AsyncSession): Database connection
         master_key (bytes): The decryption master key
-        
+
     Returns:
     -------
         Dict | None: Decrypted secrets or None if decryption fails
@@ -215,8 +213,12 @@ async def get_decrypted_secrets(
             aws_secrets = decrypt_with_private_key(encrypted_aws, private_key_b64)
 
         # Decrypt Azure secrets if they exist
-        if (secrets.azure_client_id and secrets.azure_client_secret and
-            secrets.azure_tenant_id and secrets.azure_subscription_id):
+        if (
+            secrets.azure_client_id
+            and secrets.azure_client_secret
+            and secrets.azure_tenant_id
+            and secrets.azure_subscription_id
+        ):
             encrypted_azure = {
                 "azure_client_id": secrets.azure_client_id,
                 "azure_client_secret": secrets.azure_client_secret,
@@ -225,10 +227,7 @@ async def get_decrypted_secrets(
             }
             azure_secrets = decrypt_with_private_key(encrypted_azure, private_key_b64)
 
-        return {
-            "aws": aws_secrets,
-            "azure": azure_secrets
-        }
+        return {"aws": aws_secrets, "azure": azure_secrets}
     except Exception:
         # If decryption fails, return None
         return None
@@ -274,13 +273,17 @@ async def update_user_password(
 
         # Decrypt the private key using the old master key
         try:
-            private_key_b64 = decrypt_private_key(user.encrypted_private_key, old_master_key)
+            private_key_b64 = decrypt_private_key(
+                user.encrypted_private_key, old_master_key
+            )
 
             # Generate a new master key and salt
             new_master_key, new_key_salt = generate_master_key(new_password)
 
             # Re-encrypt the private key with the new master key
-            new_encrypted_private_key = encrypt_private_key(private_key_b64, new_master_key)
+            new_encrypted_private_key = encrypt_private_key(
+                private_key_b64, new_master_key
+            )
 
             # Update the user's encrypted private key and salt
             user.encrypted_private_key = new_encrypted_private_key

--- a/src/app/crud/crud_users.py
+++ b/src/app/crud/crud_users.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -21,6 +22,8 @@ from ..utils.crypto import (
     generate_master_key,
     generate_rsa_key_pair,
 )
+
+logger = logging.getLogger(__name__)
 
 
 async def create_secret(
@@ -240,7 +243,11 @@ async def get_decrypted_secrets(
 
         return decrypted_secrets
     except Exception:
-        # If decryption fails, return None
+        logger.warning(
+            "Failed to decrypt secret when getting a secret for user: %s (%s)",
+            user.name,
+            user.id,
+        )
         return None
 
 
@@ -300,7 +307,11 @@ async def update_user_password(
             user.encrypted_private_key = new_encrypted_private_key
             user.key_salt = new_key_salt
         except Exception:
-            # If decryption fails, don't update the password
+            logger.warning(
+                "Failed to decrypt secret when updating a secret for user: %s (%s)",
+                user.name,
+                user.id,
+            )
             return False
 
     # Update the user's password

--- a/src/app/crud/crud_users.py
+++ b/src/app/crud/crud_users.py
@@ -33,7 +33,7 @@ async def create_secret(db: AsyncSession, secret: SecretSchema, user_id: UserID)
     return secret_obj
 
 
-async def get_user(db: AsyncSession, email: str) -> UserModel:
+async def get_user(db: AsyncSession, email: str) -> UserModel | None:
     """Get a user by email.
 
     Args:
@@ -63,7 +63,7 @@ async def get_user(db: AsyncSession, email: str) -> UserModel:
     return result.scalars().first()
 
 
-async def get_user_by_id(db: AsyncSession, user_id: UserID) -> UserModel:
+async def get_user_by_id(db: AsyncSession, user_id: UserID) -> UserModel | None:
     """Get a user by ID.
 
     Args:

--- a/src/app/crud/crud_users.py
+++ b/src/app/crud/crud_users.py
@@ -15,7 +15,9 @@ from ..schemas.user_schema import (
 )
 
 
-async def create_secret(db: AsyncSession, secret: SecretSchema, user_id: UserID) -> SecretModel:
+async def create_secret(
+    db: AsyncSession, secret: SecretSchema, user_id: UserID
+) -> SecretModel:
     """Create a new secret.
 
     Args:
@@ -53,8 +55,7 @@ async def get_user(db: AsyncSession, email: str) -> UserModel | None:
     """
     mapped_user_model = inspect(UserModel)
     main_columns = [
-        getattr(UserModel, attr.key)
-        for attr in mapped_user_model.column_attrs
+        getattr(UserModel, attr.key) for attr in mapped_user_model.column_attrs
     ]
 
     stmt = (
@@ -83,8 +84,7 @@ async def get_user_by_id(db: AsyncSession, user_id: UserID) -> UserModel | None:
     """
     mapped_user_model = inspect(UserModel)
     main_columns = [
-        getattr(UserModel, attr.key)
-        for attr in mapped_user_model.column_attrs
+        getattr(UserModel, attr.key) for attr in mapped_user_model.column_attrs
     ]
 
     stmt = (
@@ -98,7 +98,9 @@ async def get_user_by_id(db: AsyncSession, user_id: UserID) -> UserModel | None:
     return result.scalars().first()
 
 
-async def create_user(db: AsyncSession, openlabs_user: UserCreateBaseSchema) -> UserModel:
+async def create_user(
+    db: AsyncSession, openlabs_user: UserCreateBaseSchema
+) -> UserModel:
     """Create and add a new OpenLabsUser to the database.
 
     Args:

--- a/src/app/crud/crud_users.py
+++ b/src/app/crud/crud_users.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 from bcrypt import gensalt, hashpw
 from sqlalchemy import inspect, select
@@ -17,7 +17,7 @@ from ..schemas.user_schema import (
 
 async def create_secret(db: AsyncSession, secret: SecretSchema, user_id: UserID) -> SecretModel:
     """Create a new secret.
-    
+
     Args:
     ----
         db (AsyncSession): Database connection.

--- a/src/app/crud/crud_vpc_templates.py
+++ b/src/app/crud/crud_vpc_templates.py
@@ -119,7 +119,9 @@ async def create_vpc_template(
 
     # Add subnets
     subnet_objects = [
-        await create_subnet_template(db, subnet_data, TemplateVPCID(id=vpc_obj.id), owner_id)
+        await create_subnet_template(
+            db, subnet_data, TemplateVPCID(id=vpc_obj.id), owner_id
+        )
         for subnet_data in vpc_template.subnets
     ]
 

--- a/src/app/crud/crud_vpc_templates.py
+++ b/src/app/crud/crud_vpc_templates.py
@@ -18,7 +18,7 @@ from .crud_subnet_templates import create_subnet_template
 
 
 async def get_vpc_template_headers(
-    db: AsyncSession, user_id: uuid.UUID = None, standalone_only: bool = True
+    db: AsyncSession, user_id: uuid.UUID | None = None, standalone_only: bool = True
 ) -> list[TemplateVPCModel]:
     """Get list of VPC template headers.
 
@@ -53,7 +53,7 @@ async def get_vpc_template_headers(
 
 
 async def get_vpc_template(
-    db: AsyncSession, vpc_id: TemplateVPCID, user_id: uuid.UUID = None
+    db: AsyncSession, vpc_id: TemplateVPCID, user_id: uuid.UUID | None = None
 ) -> TemplateVPCModel | None:
     """Get VPC template by id (uuid).
 

--- a/src/app/crud/crud_vpc_templates.py
+++ b/src/app/crud/crud_vpc_templates.py
@@ -1,19 +1,18 @@
+import uuid
+
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import load_only, selectinload
-import uuid
 
 from ..models.template_subnet_model import TemplateSubnetModel
 from ..models.template_vpc_model import TemplateVPCModel
-from ..models.user_model import UserModel
 from ..schemas.template_range_schema import TemplateRangeID
 from ..schemas.template_vpc_schema import (
     TemplateVPCBaseSchema,
     TemplateVPCID,
     TemplateVPCSchema,
 )
-from ..schemas.user_schema import UserID
 from .crud_subnet_templates import create_subnet_template
 
 
@@ -41,10 +40,10 @@ async def get_vpc_template_headers(
     ]
 
     stmt = select(TemplateVPCModel).options(load_only(*main_columns))
-    
+
     if standalone_only:
         stmt = stmt.where(TemplateVPCModel.range_id.is_(None))
-        
+
     if user_id:
         stmt = stmt.where(TemplateVPCModel.owner_id == user_id)
 
@@ -77,10 +76,10 @@ async def get_vpc_template(
         )
         .filter(TemplateVPCModel.id == vpc_id.id)
     )
-    
+
     if user_id:
         stmt = stmt.filter(TemplateVPCModel.owner_id == user_id)
-        
+
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
@@ -107,11 +106,11 @@ async def create_vpc_template(
     """
     vpc_template = TemplateVPCSchema(**vpc_template.model_dump())
     vpc_dict = vpc_template.model_dump(exclude={"subnets"})
-    
+
     # Set owner ID and range ID if provided
     if owner_id:
         vpc_dict["owner_id"] = owner_id
-    
+
     if range_id:
         vpc_dict["range_id"] = range_id.id
 

--- a/src/app/crud/crud_vpc_templates.py
+++ b/src/app/crud/crud_vpc_templates.py
@@ -1,5 +1,5 @@
-import uuid
 import logging
+import uuid
 
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/app/enums/__init__.py
+++ b/src/app/enums/__init__.py
@@ -1,1 +1,1 @@
-"""Enums for the OpenLabsX API."""
+"""Enums for the OpenLabs API."""

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,1 +1,1 @@
-"""SQLAlchemy models for OpenLabsX API."""
+"""SQLAlchemy models for OpenLabs API."""

--- a/src/app/models/secret_model.py
+++ b/src/app/models/secret_model.py
@@ -8,7 +8,7 @@ from ..core.db.database import Base
 
 class SecretModel(Base):
     """SQLAlchemy ORM model for OpenLabs Secrets.
-    
+
     All secret fields are now stored encrypted using the user's public key.
     """
 

--- a/src/app/models/secret_model.py
+++ b/src/app/models/secret_model.py
@@ -23,6 +23,8 @@ class SecretModel(Base):
 
     azure_client_id: Mapped[str] = mapped_column(String, nullable=True)
     azure_client_secret: Mapped[str] = mapped_column(String, nullable=True)
+    azure_tenant_id: Mapped[str] = mapped_column(String, nullable=True)
+    azure_subscription_id: Mapped[str] = mapped_column(String, nullable=True)
     azure_created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/src/app/models/secret_model.py
+++ b/src/app/models/secret_model.py
@@ -1,13 +1,16 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy import DateTime, ForeignKey, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
 
 
 class SecretModel(Base):
-    """SQLAlchemy ORM model for OpenLabs Secrets."""
+    """SQLAlchemy ORM model for OpenLabs Secrets.
+    
+    All secret fields are now stored encrypted using the user's public key.
+    """
 
     __tablename__ = "secrets"
 
@@ -15,16 +18,18 @@ class SecretModel(Base):
         ForeignKey("users.id"), nullable=False, primary_key=True
     )
 
-    aws_access_key: Mapped[str] = mapped_column(String, nullable=True)
-    aws_secret_key: Mapped[str] = mapped_column(String, nullable=True)
+    # AWS credentials - encrypted with user's public key
+    aws_access_key: Mapped[str] = mapped_column(Text, nullable=True)
+    aws_secret_key: Mapped[str] = mapped_column(Text, nullable=True)
     aws_created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
 
-    azure_client_id: Mapped[str] = mapped_column(String, nullable=True)
-    azure_client_secret: Mapped[str] = mapped_column(String, nullable=True)
-    azure_tenant_id: Mapped[str] = mapped_column(String, nullable=True)
-    azure_subscription_id: Mapped[str] = mapped_column(String, nullable=True)
+    # Azure credentials - encrypted with user's public key
+    azure_client_id: Mapped[str] = mapped_column(Text, nullable=True)
+    azure_client_secret: Mapped[str] = mapped_column(Text, nullable=True)
+    azure_tenant_id: Mapped[str] = mapped_column(Text, nullable=True)
+    azure_subscription_id: Mapped[str] = mapped_column(Text, nullable=True)
     azure_created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/src/app/models/secret_model.py
+++ b/src/app/models/secret_model.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, String
@@ -12,14 +11,20 @@ class SecretModel(Base):
 
     __tablename__ = "secrets"
 
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), nullable=False, primary_key=True
+    )
 
     aws_access_key: Mapped[str] = mapped_column(String, nullable=True)
     aws_secret_key: Mapped[str] = mapped_column(String, nullable=True)
-    aws_created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
+    aws_created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     azure_client_id: Mapped[str] = mapped_column(String, nullable=True)
     azure_client_secret: Mapped[str] = mapped_column(String, nullable=True)
-    azure_created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
+    azure_created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     user = relationship("UserModel", back_populates="secrets")

--- a/src/app/models/secret_model.py
+++ b/src/app/models/secret_model.py
@@ -1,12 +1,11 @@
-import uuid
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, String, DateTime
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
+
 
 class SecretModel(Base):
     """SQLAlchemy ORM model for OpenLabs Secrets."""
@@ -17,10 +16,10 @@ class SecretModel(Base):
 
     aws_access_key: Mapped[str] = mapped_column(String, nullable=True)
     aws_secret_key: Mapped[str] = mapped_column(String, nullable=True)
-    aws_created_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    aws_created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
 
     azure_client_id: Mapped[str] = mapped_column(String, nullable=True)
     azure_client_secret: Mapped[str] = mapped_column(String, nullable=True)
-    azure_created_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    azure_created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
 
     user = relationship("UserModel", back_populates="secrets")

--- a/src/app/models/template_base_model.py
+++ b/src/app/models/template_base_model.py
@@ -2,7 +2,7 @@ import uuid
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column, relationship
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 
 class OpenLabsTemplateMixin(MappedAsDataclass):
@@ -12,7 +12,7 @@ class OpenLabsTemplateMixin(MappedAsDataclass):
         UUID(as_uuid=True),
         primary_key=True,
     )
-    
+
     # User who owns this template
     owner_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),

--- a/src/app/models/template_base_model.py
+++ b/src/app/models/template_base_model.py
@@ -1,7 +1,8 @@
 import uuid
 
+from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column, relationship
 
 
 class OpenLabsTemplateMixin(MappedAsDataclass):
@@ -11,6 +12,14 @@ class OpenLabsTemplateMixin(MappedAsDataclass):
         UUID(as_uuid=True),
         primary_key=True,
     )
+    
+    # User who owns this template
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
 
 class OpenLabsUserMixin(MappedAsDataclass):
     """Mixin to provide a UUID for each user-based model."""

--- a/src/app/models/user_model.py
+++ b/src/app/models/user_model.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy import Boolean, DateTime, LargeBinary, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
@@ -23,6 +23,11 @@ class UserModel(Base, OpenLabsUserMixin):
     )
 
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    # Encryption-related fields
+    public_key: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    encrypted_private_key: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    key_salt: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True, default=None)
 
     # One-to-one relationship with secrets.
     # For now, users can only have one azure or one aws secret

--- a/src/app/models/user_model.py
+++ b/src/app/models/user_model.py
@@ -26,8 +26,12 @@ class UserModel(Base, OpenLabsUserMixin):
 
     # Encryption-related fields
     public_key: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
-    encrypted_private_key: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
-    key_salt: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True, default=None)
+    encrypted_private_key: Mapped[str | None] = mapped_column(
+        Text, nullable=True, default=None
+    )
+    key_salt: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True, default=None
+    )
 
     # One-to-one relationship with secrets.
     # For now, users can only have one azure or one aws secret

--- a/src/app/models/user_model.py
+++ b/src/app/models/user_model.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, String, DateTime
+from sqlalchemy import Boolean, DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
 from .template_base_model import OpenLabsUserMixin
+
 
 class UserModel(Base, OpenLabsUserMixin):
     """SQLAlchemy ORM model for User."""
@@ -14,11 +15,11 @@ class UserModel(Base, OpenLabsUserMixin):
     name: Mapped[str] = mapped_column(String, nullable=False)
     email: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     hashed_password: Mapped[str] = mapped_column(String, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-    last_active: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_active: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
 
-    # One-to-one relationship with secrets. 
+    # One-to-one relationship with secrets.
     # For now, users can only have one azure or one aws secret
     secrets = relationship("SecretModel", back_populates="user", cascade="all, delete-orphan", uselist=False)

--- a/src/app/models/user_model.py
+++ b/src/app/models/user_model.py
@@ -4,7 +4,7 @@ from sqlalchemy import Boolean, String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
-from .openlabs_base_model import OpenLabsUserMixin
+from .template_base_model import OpenLabsUserMixin
 
 class UserModel(Base, OpenLabsUserMixin):
     """SQLAlchemy ORM model for User."""

--- a/src/app/models/user_model.py
+++ b/src/app/models/user_model.py
@@ -15,11 +15,20 @@ class UserModel(Base, OpenLabsUserMixin):
     name: Mapped[str] = mapped_column(String, nullable=False)
     email: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     hashed_password: Mapped[str] = mapped_column(String, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    last_active: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    last_active: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
 
     # One-to-one relationship with secrets.
     # For now, users can only have one azure or one aws secret
-    secrets = relationship("SecretModel", back_populates="user", cascade="all, delete-orphan", uselist=False)
+    secrets = relationship(
+        "SecretModel",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )

--- a/src/app/schemas/__init__.py
+++ b/src/app/schemas/__init__.py
@@ -1,1 +1,1 @@
-"""OpenLabsX API schemas."""
+"""OpenLabs API schemas."""

--- a/src/app/schemas/message_schema.py
+++ b/src/app/schemas/message_schema.py
@@ -1,0 +1,41 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class MessageSchema(BaseModel):
+    """Generic JSON response schema for OpenLabs."""
+
+    message: str = Field(..., description="Response message")
+
+
+class UpdatePasswordMessageSchema(MessageSchema):
+    """Password update response schema for OpenLabs."""
+
+    message: Literal[
+        "Password updated successfully", "Current password is incorrect"
+    ] = Field(..., description="Message indicating password reset status")
+
+
+class AWSUpdateSecretMessageSchema(MessageSchema):
+    """AWS update secret response schema for OpenLabs."""
+
+    message: Literal["AWS credentials updated successfully"] = Field(...)
+
+
+class AzureUpdateSecretMessageSchema(MessageSchema):
+    """Azure update secret response schema for OpenLabs."""
+
+    message: Literal["Azure credentials updated successfully"] = Field(...)
+
+
+class UserLoginMessageSchema(BaseModel):
+    """User login response schema for OpenLabs."""
+
+    success: bool = Field(..., description="Whether or not login was successfull")
+
+
+class UserLogoutMessageSchema(BaseModel):
+    """User logout response schema for OpenLabs."""
+
+    success: bool = Field(..., description="Whether or not logout was successfull")

--- a/src/app/schemas/secret_schema.py
+++ b/src/app/schemas/secret_schema.py
@@ -30,12 +30,12 @@ class SecretBaseSchema(BaseModel):
         default=None,
         description="Client secret for Azure",
     )
-    
+
     azure_tenant_id: str | None = Field(
         default=None,
         description="Tenant ID for Azure",
     )
-    
+
     azure_subscription_id: str | None = Field(
         default=None,
         description="Subscription ID for Azure",

--- a/src/app/schemas/secret_schema.py
+++ b/src/app/schemas/secret_schema.py
@@ -68,3 +68,17 @@ class AzureSecrets(BaseModel):
     azure_client_secret: str
     azure_tenant_id: str
     azure_subscription_id: str
+
+
+class CloudSecretStatusSchema(BaseModel):
+    """General response schema for a single cloud provider."""
+
+    has_credentials: bool
+    created_at: datetime | None
+
+
+class UserSecretResponseSchema(BaseModel):
+    """Response schema for retrieving user secret status."""
+
+    aws: CloudSecretStatusSchema
+    azure: CloudSecretStatusSchema

--- a/src/app/schemas/secret_schema.py
+++ b/src/app/schemas/secret_schema.py
@@ -30,6 +30,16 @@ class SecretBaseSchema(BaseModel):
         default=None,
         description="Client secret for Azure",
     )
+    
+    azure_tenant_id: str | None = Field(
+        default=None,
+        description="Tenant ID for Azure",
+    )
+    
+    azure_subscription_id: str | None = Field(
+        default=None,
+        description="Subscription ID for Azure",
+    )
 
     azure_created_at: datetime | None = Field(
         default=None,
@@ -56,3 +66,5 @@ class AzureSecrets(BaseModel):
 
     azure_client_id: str
     azure_client_secret: str
+    azure_tenant_id: str
+    azure_subscription_id: str

--- a/src/app/schemas/secret_schema.py
+++ b/src/app/schemas/secret_schema.py
@@ -57,28 +57,59 @@ class SecretSchema(SecretBaseSchema):
 class AWSSecrets(BaseModel):
     """AWS secret object for setting secrets on OpenLabs."""
 
-    aws_access_key: str
-    aws_secret_key: str
+    aws_access_key: str = Field(
+        ...,
+        description="Access key for AWS account",
+    )
+    aws_secret_key: str = Field(
+        ...,
+        description="Secret key for AWS account",
+    )
 
 
 class AzureSecrets(BaseModel):
     """Azure secret object for setting secrets on OpenLabs."""
 
-    azure_client_id: str
-    azure_client_secret: str
-    azure_tenant_id: str
-    azure_subscription_id: str
+    azure_client_id: str = Field(
+        ...,
+        description="Client ID for Azure",
+    )
+    azure_client_secret: str = Field(
+        ...,
+        description="Client secret for Azure",
+    )
+    azure_tenant_id: str = Field(
+        ...,
+        description="Tenant ID for Azure",
+    )
+    azure_subscription_id: str = Field(
+        ...,
+        description="Subscription ID for Azure",
+    )
 
 
 class CloudSecretStatusSchema(BaseModel):
     """General response schema for a single cloud provider."""
 
-    has_credentials: bool
-    created_at: datetime | None
+    has_credentials: bool = Field(
+        ...,
+        description="Indicates if the credentials are present",
+    )
+    created_at: datetime | None = Field(
+        default=None,
+        description="Time the secrets were created",
+        examples=[datetime(2025, 2, 5, tzinfo=timezone.utc)],
+    )
 
 
 class UserSecretResponseSchema(BaseModel):
     """Response schema for retrieving user secret status."""
 
-    aws: CloudSecretStatusSchema
-    azure: CloudSecretStatusSchema
+    aws: CloudSecretStatusSchema = Field(
+        ...,
+        description="Status of AWS credentials",
+    )
+    azure: CloudSecretStatusSchema = Field(
+        ...,
+        description="Status of Azure credentials",
+    )

--- a/src/app/schemas/secret_schema.py
+++ b/src/app/schemas/secret_schema.py
@@ -42,3 +42,17 @@ class SecretSchema(SecretBaseSchema):
     """Secret object for OpenLabs."""
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class AWSSecrets(BaseModel):
+    """AWS secret object for setting secrets on OpenLabs."""
+
+    aws_access_key: str
+    aws_secret_key: str
+
+
+class AzureSecrets(BaseModel):
+    """Azure secret object for setting secrets on OpenLabs."""
+
+    azure_client_id: str
+    azure_client_secret: str

--- a/src/app/schemas/secret_schema.py
+++ b/src/app/schemas/secret_schema.py
@@ -1,6 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+
 
 class SecretBaseSchema(BaseModel):
     """Base secret object for OpenLabs."""
@@ -17,7 +18,7 @@ class SecretBaseSchema(BaseModel):
     aws_created_at: datetime | None = Field(
         default=None,
         description="Time AWS secrets were populated",
-        examples=[datetime(2025, 2, 5)]
+        examples=[datetime(2025, 2, 5, tzinfo=timezone.utc)]
     )
 
     azure_client_id: str | None = Field(
@@ -33,7 +34,7 @@ class SecretBaseSchema(BaseModel):
     azure_created_at: datetime | None = Field(
         default=None,
         description="Time Azure secrets were populated",
-        examples=[datetime(2025, 2, 5)]
+        examples=[datetime(2025, 2, 5, tzinfo=timezone.utc)]
     )
 
 class SecretSchema(SecretBaseSchema):

--- a/src/app/schemas/secret_schema.py
+++ b/src/app/schemas/secret_schema.py
@@ -18,7 +18,7 @@ class SecretBaseSchema(BaseModel):
     aws_created_at: datetime | None = Field(
         default=None,
         description="Time AWS secrets were populated",
-        examples=[datetime(2025, 2, 5, tzinfo=timezone.utc)]
+        examples=[datetime(2025, 2, 5, tzinfo=timezone.utc)],
     )
 
     azure_client_id: str | None = Field(
@@ -34,8 +34,9 @@ class SecretBaseSchema(BaseModel):
     azure_created_at: datetime | None = Field(
         default=None,
         description="Time Azure secrets were populated",
-        examples=[datetime(2025, 2, 5, tzinfo=timezone.utc)]
+        examples=[datetime(2025, 2, 5, tzinfo=timezone.utc)],
     )
+
 
 class SecretSchema(SecretBaseSchema):
     """Secret object for OpenLabs."""

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -20,7 +20,7 @@ class UserBaseSchema(BaseModel):
 
     @field_validator("email")
     @classmethod
-    def validate_email(cls, email: str, info: ValidationInfo) -> str:
+    def validate_email(cls, email: str, _: ValidationInfo) -> str:
         """Check that email format is valid.
 
         Args:
@@ -34,9 +34,6 @@ class UserBaseSchema(BaseModel):
             str: User email address.
 
         """
-        # This import is not used, but must match for UserCreateBaseSchema
-        del info
-
         try:
             emailinfo = validate_email(email, check_deliverability=False)
 

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -35,6 +35,7 @@ class UserBaseSchema(BaseModel):
 
         """
         # This import is not used, but must match for UserCreateBaseSchema
+        del info
 
         try:
             emailinfo = validate_email(email, check_deliverability=False)
@@ -102,3 +103,24 @@ class UserCreateSchema(UserCreateBaseSchema, UserID):
     """User creation object for OpenLabs."""
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class UserInfoResponseSchema(BaseModel):
+    """User information response object for user page on OpenLabs Frontend."""
+
+    name: str
+    email: str
+
+
+class PasswordUpdateSchema(BaseModel):
+    """Schema for updating user password."""
+
+    current_password: str = Field(
+        ...,
+        description="Current password of user",
+        min_length=1,
+        examples=["password123"],
+    )
+    new_password: str = Field(
+        ..., description="New password of user", min_length=1, examples=["password123!"]
+    )

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -10,7 +10,7 @@ class UserBaseSchema(BaseModel):
     email: str = Field(
         ...,
         description="Email of user",
-        min_length=1,
+        min_length=3,
         examples=["adam@ufsit.club", "alex@christy.com", "naresh@panch.al"],
     )
 
@@ -114,7 +114,7 @@ class UserInfoResponseSchema(BaseModel):
     email: str = Field(
         ...,
         description="Email of user",
-        min_length=1,
+        min_length=3,
         examples=["adam@ufsit.club", "alex@christy.com", "naresh@panch.al"],
     )
     admin: bool = Field(

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -105,8 +105,23 @@ class UserCreateSchema(UserCreateBaseSchema, UserID):
 class UserInfoResponseSchema(BaseModel):
     """User information response object for user page on OpenLabs Frontend."""
 
-    name: str
-    email: str
+    name: str = Field(
+        ...,
+        description="Full name of user",
+        min_length=1,
+        examples=["Adam Hassan", "Alex Christy", "Naresh Panchal"],
+    )
+    email: str = Field(
+        ...,
+        description="Email of user",
+        min_length=1,
+        examples=["adam@ufsit.club", "alex@christy.com", "naresh@panch.al"],
+    )
+    admin: bool = Field(
+        ...,
+        description="Admin status of user",
+        examples=[True, False],
+    )
 
 
 class PasswordUpdateSchema(BaseModel):

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -15,7 +15,7 @@ class UserBaseSchema(BaseModel):
     )
 
     password: str = Field(
-        ..., description="Password of user", min_length=1, examples=["password123"]
+        ..., description="Password of user", min_length=8, examples=["password123"]
     )
 
     @field_validator("email")
@@ -130,9 +130,9 @@ class PasswordUpdateSchema(BaseModel):
     current_password: str = Field(
         ...,
         description="Current password of user",
-        min_length=1,
+        min_length=8,
         examples=["password123"],
     )
     new_password: str = Field(
-        ..., description="New password of user", min_length=1, examples=["password123!"]
+        ..., description="New password of user", min_length=8, examples=["password123!"]
     )

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -1,8 +1,8 @@
 import uuid
-import datetime
 
-from pydantic import BaseModel, Field, field_validator, ConfigDict
-from email_validator import validate_email, EmailNotValidError
+from email_validator import EmailNotValidError, validate_email
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
 
 class UserBaseSchema(BaseModel):
     """Schema for user authentication."""
@@ -26,22 +26,24 @@ class UserBaseSchema(BaseModel):
     def validate_email(
         cls, email: str) -> str:
         """Check that email format is valid.
+
         Args:
         ----
             cls: OpenLabsUser object.
             email (str): User email address.
+
         Returns:
         -------
             str: User email address.
-        """
 
+        """
         try:
             emailinfo = validate_email(email, check_deliverability=False)
 
             return emailinfo.normalized
-        except EmailNotValidError:
+        except EmailNotValidError as e:
             msg = "Provided email address is invalid."
-            raise ValueError(msg)
+            raise ValueError(msg) from e
 
 class UserCreateBaseSchema(UserBaseSchema):
     """User object for user creation in OpenLabs."""
@@ -58,24 +60,26 @@ class UserCreateBaseSchema(UserBaseSchema):
     def validate_email(
         cls, email: str) -> str:
         """Check that email format is valid.
+
         Args:
         ----
             cls: OpenLabsUser object.
             email (str): User email address.
+
         Returns:
         -------
             str: User email address.
-        """
 
+        """
         try:
             # Makes a DNS query to validate deliverability
             # We do this, as users will only be added to DB on registration
             emailinfo = validate_email(email, check_deliverability=True)
 
             return emailinfo.normalized
-        except EmailNotValidError:
+        except EmailNotValidError as e:
             msg = "Provided email address is invalid."
-            raise ValueError(msg)
+            raise ValueError(msg) from e
 
 
 class UserID(BaseModel):

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -1,5 +1,5 @@
 import uuid
-iport datetime
+import datetime
 
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from email_validator import validate_email, EmailNotValidError

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -20,19 +20,22 @@ class UserBaseSchema(BaseModel):
 
     @field_validator("email")
     @classmethod
-    def validate_email(cls, email: str) -> str:
+    def validate_email(cls, email: str, info: ValidationInfo) -> str:
         """Check that email format is valid.
 
         Args:
         ----
             cls: OpenLabsUser object.
             email (str): User email address.
+            info (ValidatonInfo): Validator context
 
         Returns:
         -------
             str: User email address.
 
         """
+        # This import is not used, but must match for UserCreateBaseSchema
+
         try:
             emailinfo = validate_email(email, check_deliverability=False)
 
@@ -72,7 +75,8 @@ class UserCreateBaseSchema(UserBaseSchema):
         try:
             # Skip deliverability check if user is admin (system default)
             if is_admin:
-                return email
+                emailinfo = validate_email(email, check_deliverability=False)
+                return emailinfo.normalized
 
             # Makes a DNS query to validate deliverability
             # We do this, as users will only be added to DB on registration

--- a/src/app/schemas/user_schema.py
+++ b/src/app/schemas/user_schema.py
@@ -15,16 +15,12 @@ class UserBaseSchema(BaseModel):
     )
 
     password: str = Field(
-        ...,
-        description = "Password of user",
-        min_length = 1,
-        examples=["password123"]
+        ..., description="Password of user", min_length=1, examples=["password123"]
     )
 
     @field_validator("email")
     @classmethod
-    def validate_email(
-        cls, email: str) -> str:
+    def validate_email(cls, email: str) -> str:
         """Check that email format is valid.
 
         Args:
@@ -45,6 +41,7 @@ class UserBaseSchema(BaseModel):
             msg = "Provided email address is invalid."
             raise ValueError(msg) from e
 
+
 class UserCreateBaseSchema(UserBaseSchema):
     """User object for user creation in OpenLabs."""
 
@@ -52,13 +49,12 @@ class UserCreateBaseSchema(UserBaseSchema):
         ...,
         description="Full name of user",
         min_length=1,
-        examples=["Adam Hassan", "Alex Christy", "Naresh Panchal"]
+        examples=["Adam Hassan", "Alex Christy", "Naresh Panchal"],
     )
 
     @field_validator("email")
     @classmethod
-    def validate_email(
-        cls, email: str) -> str:
+    def validate_email(cls, email: str) -> str:
         """Check that email format is valid.
 
         Args:
@@ -90,6 +86,7 @@ class UserID(BaseModel):
     )
 
     model_config = ConfigDict(from_attributes=True)
+
 
 class UserCreateSchema(UserCreateBaseSchema, UserID):
     """User creation object for OpenLabs."""

--- a/src/app/utils/__init__.py
+++ b/src/app/utils/__init__.py
@@ -1,1 +1,1 @@
-"""Utilities for the OpenLabsX API."""
+"""Utilities for the OpenLabs API."""

--- a/src/app/utils/crypto.py
+++ b/src/app/utils/crypto.py
@@ -7,6 +7,7 @@ from cryptography.fernet import Fernet
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 
 
 # RSA Key Generation
@@ -98,9 +99,10 @@ def encrypt_with_public_key(
 ) -> Dict[str, str]:
     """Encrypt a dictionary of string data using the RSA public key."""
     public_key_bytes = base64.b64decode(public_key_b64)
-    public_key = serialization.load_pem_public_key(
+    loaded_key: RSAPublicKey = serialization.load_pem_public_key(  # type: ignore
         public_key_bytes, backend=default_backend()
     )
+    public_key = loaded_key
 
     encrypted_data = {}
 
@@ -133,9 +135,10 @@ def decrypt_with_private_key(
 ) -> Dict[str, str]:
     """Decrypt a dictionary of encrypted data using the RSA private key."""
     private_key_bytes = base64.b64decode(private_key_b64)
-    private_key = serialization.load_pem_private_key(
+    loaded_key: RSAPrivateKey = serialization.load_pem_private_key(  # type: ignore
         private_key_bytes, password=None, backend=default_backend()
     )
+    private_key = loaded_key
 
     decrypted_data = {}
 

--- a/src/app/utils/crypto.py
+++ b/src/app/utils/crypto.py
@@ -1,0 +1,167 @@
+import base64
+import os
+from typing import Dict, Tuple
+
+from argon2.low_level import Type, hash_secret_raw
+from cryptography.fernet import Fernet
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+
+# RSA Key Generation
+def generate_rsa_key_pair() -> Tuple[str, str]:
+    """Generate an RSA key pair and return base64 encoded strings."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+
+    public_key = private_key.public_key()
+
+    # Serialize private key
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption()
+    )
+
+    # Serialize public key
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    # Encode to base64 for storage
+    private_b64 = base64.b64encode(private_pem).decode("utf-8")
+    public_b64 = base64.b64encode(public_pem).decode("utf-8")
+
+    return private_b64, public_b64
+
+
+# Master Key Generation using Argon2
+def generate_master_key(password: str, salt: bytes = None) -> Tuple[bytes, bytes]:
+    """Generate a master key using Argon2 from a password."""
+    if salt is None:
+        salt = os.urandom(16)
+
+    # Generate a raw hash to use as a key
+    key = hash_secret_raw(
+        secret=password.encode("utf-8"),
+        salt=salt,
+        time_cost=3,        # Number of iterations
+        memory_cost=65536,  # Memory usage in kibibytes (64 MB)
+        parallelism=4,      # Number of parallel threads
+        hash_len=32,        # Length of the hash
+        type=Type.ID        # Argon2id variant
+    )
+
+    return key, salt
+
+
+# Encrypt the RSA private key with the master key
+def encrypt_private_key(private_key_b64: str, master_key: bytes) -> str:
+    """Encrypt the RSA private key using the master key."""
+    private_key_bytes = base64.b64decode(private_key_b64)
+
+    # Create a Fernet instance with the master key
+    fernet_key = base64.urlsafe_b64encode(master_key)
+    fernet = Fernet(fernet_key)
+
+    # Encrypt the private key
+    encrypted_key = fernet.encrypt(private_key_bytes)
+
+    # Encode to base64 for storage
+    encrypted_key_b64 = base64.b64encode(encrypted_key).decode("utf-8")
+
+    return encrypted_key_b64
+
+
+# Decrypt the RSA private key with the master key
+def decrypt_private_key(encrypted_key_b64: str, master_key: bytes) -> str:
+    """Decrypt the RSA private key using the master key."""
+    encrypted_key = base64.b64decode(encrypted_key_b64)
+
+    # Create a Fernet instance with the master key
+    fernet_key = base64.urlsafe_b64encode(master_key)
+    fernet = Fernet(fernet_key)
+
+    # Decrypt the private key
+    private_key_bytes = fernet.decrypt(encrypted_key)
+
+    # Encode to base64
+    private_key_b64 = base64.b64encode(private_key_bytes).decode("utf-8")
+
+    return private_key_b64
+
+
+# Encrypt data with RSA public key
+def encrypt_with_public_key(data: Dict[str, str], public_key_b64: str) -> Dict[str, str]:
+    """Encrypt a dictionary of string data using the RSA public key."""
+    public_key_bytes = base64.b64decode(public_key_b64)
+    public_key = serialization.load_pem_public_key(
+        public_key_bytes,
+        backend=default_backend()
+    )
+
+    encrypted_data = {}
+
+    for key, value in data.items():
+        if value:  # Only encrypt non-empty values
+            # Convert string to bytes
+            value_bytes = value.encode("utf-8")
+
+            # Encrypt with public key
+            encrypted_value = public_key.encrypt(
+                value_bytes,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
+                    label=None
+                )
+            )
+
+            # Encode to base64 for storage
+            encrypted_data[key] = base64.b64encode(encrypted_value).decode("utf-8")
+        else:
+            encrypted_data[key] = ""  # Keep empty values as empty
+
+    return encrypted_data
+
+
+# Decrypt data with RSA private key
+def decrypt_with_private_key(
+    encrypted_data: Dict[str, str],
+    private_key_b64: str
+) -> Dict[str, str]:
+    """Decrypt a dictionary of encrypted data using the RSA private key."""
+    private_key_bytes = base64.b64decode(private_key_b64)
+    private_key = serialization.load_pem_private_key(
+        private_key_bytes,
+        password=None,
+        backend=default_backend()
+    )
+
+    decrypted_data = {}
+
+    for key, value in encrypted_data.items():
+        if value:  # Only decrypt non-empty values
+            # Decode from base64
+            encrypted_value = base64.b64decode(value)
+
+            # Decrypt with private key
+            decrypted_value = private_key.decrypt(
+                encrypted_value,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
+                    label=None
+                )
+            )
+
+            decrypted_data[key] = decrypted_value.decode("utf-8")
+        else:
+            decrypted_data[key] = ""  # Keep empty values as empty
+
+    return decrypted_data

--- a/src/app/validators/__init__.py
+++ b/src/app/validators/__init__.py
@@ -1,1 +1,1 @@
-"""Validators for the OpenLabsX API."""
+"""Validators for the OpenLabs API."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for OpenLabsX API."""
+"""Tests for OpenLabs API."""

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,1 +1,1 @@
-"""API endpoint tests for the OpenLabsX API."""
+"""API endpoint tests for the OpenLabs API."""

--- a/tests/api/v1/__init__.py
+++ b/tests/api/v1/__init__.py
@@ -1,1 +1,1 @@
-"""Version 1 API endpoint tests for the OpenLabsX API."""
+"""Version 1 API endpoint tests for the OpenLabs API."""

--- a/tests/api/v1/config.py
+++ b/tests/api/v1/config.py
@@ -1,2 +1,77 @@
+import copy
+from typing import Any
+
 # Base route
 BASE_ROUTE = "/api/v1"
+
+
+# ==============================
+#       Template Payloads
+# ==============================
+
+# Valid payload for comparison
+valid_range_payload: dict[str, Any] = {
+    "vpcs": [
+        {
+            "cidr": "192.168.0.0/16",
+            "name": "example-vpc-1",
+            "subnets": [
+                {
+                    "cidr": "192.168.1.0/24",
+                    "name": "example-subnet-1",
+                    "hosts": [
+                        {
+                            "hostname": "example-host-1",
+                            "os": "debian_11",
+                            "spec": "tiny",
+                            "size": 8,
+                            "tags": ["web", "linux"],
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+    "provider": "aws",
+    "name": "example-range-1",
+    "vnc": False,
+    "vpn": False,
+}
+
+valid_vpc_payload = copy.deepcopy(valid_range_payload["vpcs"][0])
+valid_subnet_payload = copy.deepcopy(valid_vpc_payload["subnets"][0])
+valid_host_payload = copy.deepcopy(valid_subnet_payload["hosts"][0])
+
+# ==============================
+#      User/Auth Payloads
+# ==============================
+
+# Test user credentials
+base_user_register_payload = {
+    "email": "test@ufsit.club",
+    "password": "password123",
+    "name": "Test User",
+}
+
+base_user_login_payload = copy.deepcopy(base_user_register_payload)
+base_user_login_payload.pop("name")
+
+# Test data for password update
+password_update_payload = {
+    "current_password": "password123",
+    "new_password": "newpassword123",
+}
+
+# Test data for AWS secrets
+aws_secrets_payload = {
+    "aws_access_key": "AKIAIOSFODNN7EXAMPLE",
+    "aws_secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+}
+
+# Test data for Azure secrets
+azure_secrets_payload = {
+    "azure_client_id": "00000000-0000-0000-0000-000000000000",
+    "azure_client_secret": "example-client-secret-value",
+    "azure_tenant_id": "00000000-0000-0000-0000-000000000000",
+    "azure_subscription_id": "00000000-0000-0000-0000-000000000000",
+}

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -28,6 +28,13 @@ async def test_user_register(client: AsyncClient) -> None:
     uuid_obj = uuid.UUID(uuid_response, version=4)
     assert str(uuid_obj) == uuid_response
 
+async def test_user_register_bad_email(client: AsyncClient) -> None:
+    """Test that we get a 422 response when registering a user with an invalid email."""
+    invalid_payload = copy.deepcopy(user_register_payload)
+    invalid_payload["email"] = "invalidemail"
+
+    response = await client.post(f"{BASE_ROUTE}/auth/register", json=invalid_payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 async def test_duplicate_user_register(client: AsyncClient) -> None:
     """Test that we get a 400 response when registering a user with the same email."""

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -5,16 +5,13 @@ import copy
 from httpx import AsyncClient
 
 from fastapi import status
+from .config import base_user_register_payload, base_user_login_payload
 
+user_register_payload = copy.deepcopy(base_user_register_payload)
+user_login_payload = copy.deepcopy(base_user_login_payload)
 
-user_register_payload = {
-    "email": "test-auth@ufsit.club",
-    "password": "password123",
-    "name": "Adam Hassan",
-}
-
-user_login_payload = copy.deepcopy(user_register_payload)
-user_login_payload.pop("name")
+user_register_payload["email"] = "test-auth@ufsit.club"
+user_login_payload["email"] = user_register_payload["email"]
 
 
 async def test_user_register(client: AsyncClient) -> None:

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -28,6 +28,7 @@ async def test_user_register(client: AsyncClient) -> None:
     uuid_obj = uuid.UUID(uuid_response, version=4)
     assert str(uuid_obj) == uuid_response
 
+
 async def test_user_register_bad_email(client: AsyncClient) -> None:
     """Test that we get a 422 response when registering a user with an invalid email."""
     invalid_payload = copy.deepcopy(user_register_payload)
@@ -35,6 +36,7 @@ async def test_user_register_bad_email(client: AsyncClient) -> None:
 
     response = await client.post(f"{BASE_ROUTE}/auth/register", json=invalid_payload)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 async def test_duplicate_user_register(client: AsyncClient) -> None:
     """Test that we get a 400 response when registering a user with the same email."""

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -1,4 +1,3 @@
-
 from .config import BASE_ROUTE
 import uuid
 import copy
@@ -20,33 +19,42 @@ user_login_payload.pop("name")
 
 async def test_user_register(client: AsyncClient) -> None:
     """Test that we get a 200 response when registering a user."""
-    response = await client.post(f"{BASE_ROUTE}/auth/register", json=user_register_payload)
+    response = await client.post(
+        f"{BASE_ROUTE}/auth/register", json=user_register_payload
+    )
     assert response.status_code == status.HTTP_200_OK
 
     uuid_response = response.json()["id"]
     uuid_obj = uuid.UUID(uuid_response, version=4)
     assert str(uuid_obj) == uuid_response
 
+
 async def test_duplicate_user_register(client: AsyncClient) -> None:
     """Test that we get a 400 response when registering a user with the same email."""
-    response = await client.post(f"{BASE_ROUTE}/auth/register", json=user_register_payload)
+    response = await client.post(
+        f"{BASE_ROUTE}/auth/register", json=user_register_payload
+    )
     assert response.status_code == status.HTTP_409_CONFLICT
 
     response_json = response.json()
     assert response_json["detail"] == "User already exists"
+
 
 async def test_duplicate_user_diff_name_pass_register(client: AsyncClient) -> None:
     """Test that we get a 400 response when registering a user with the same email but a different password and name."""
-    
+
     new_user_register_payload = copy.deepcopy(user_register_payload)
     new_user_register_payload["password"] = "newpassword123"
     new_user_register_payload["name"] = "New Name"
-    
-    response = await client.post(f"{BASE_ROUTE}/auth/register", json=user_register_payload)
+
+    response = await client.post(
+        f"{BASE_ROUTE}/auth/register", json=user_register_payload
+    )
     assert response.status_code == status.HTTP_409_CONFLICT
 
     response_json = response.json()
     assert response_json["detail"] == "User already exists"
+
 
 async def test_user_register_invalid_payload(client: AsyncClient) -> None:
     """Test that we get a 422 response when registering a user with an invalid payload."""
@@ -68,6 +76,7 @@ async def test_user_register_invalid_payload(client: AsyncClient) -> None:
     response = await client.post(f"{BASE_ROUTE}/auth/register", json=invalid_payload)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+
 async def test_user_login_correct_pass(client: AsyncClient) -> None:
     """Test that we get a 200 response when logging in a user and get a valid JWT."""
     response = await client.post(f"{BASE_ROUTE}/auth/login", json=user_login_payload)
@@ -76,6 +85,7 @@ async def test_user_login_correct_pass(client: AsyncClient) -> None:
     jwt = response.json()["token"]
     assert jwt
 
+
 async def test_user_login_incorrect_pass(client: AsyncClient) -> None:
     """Test that we get a 401 response when logging in a user with an incorrect password."""
     invalid_payload = copy.deepcopy(user_login_payload)
@@ -83,6 +93,7 @@ async def test_user_login_incorrect_pass(client: AsyncClient) -> None:
 
     response = await client.post(f"{BASE_ROUTE}/auth/login", json=invalid_payload)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
 
 async def test_nonexistent_user_login(client: AsyncClient) -> None:
     """Test that we get a 401 response when logging in a user that doesn't exist."""

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -9,7 +9,7 @@ from fastapi import status
 
 
 user_register_payload = {
-    "email": "adam@ufsit.club",
+    "email": "test-auth@ufsit.club",
     "password": "password123",
     "name": "Adam Hassan",
 }

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -78,12 +78,15 @@ async def test_user_register_invalid_payload(client: AsyncClient) -> None:
 
 
 async def test_user_login_correct_pass(client: AsyncClient) -> None:
-    """Test that we get a 200 response when logging in a user and get a valid JWT."""
+    """Test that we get a 200 response when logging in a user and get a valid JWT cookie."""
     response = await client.post(f"{BASE_ROUTE}/auth/login", json=user_login_payload)
     assert response.status_code == status.HTTP_200_OK
 
-    jwt = response.json()["token"]
-    assert jwt
+    # Check that the response contains a success message
+    assert response.json()["success"] == True
+
+    # Check that the cookie is set
+    assert "token" in response.cookies
 
 
 async def test_user_login_incorrect_pass(client: AsyncClient) -> None:
@@ -102,3 +105,46 @@ async def test_nonexistent_user_login(client: AsyncClient) -> None:
 
     response = await client.post(f"{BASE_ROUTE}/auth/login", json=invalid_payload)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+async def test_user_logout(client: AsyncClient) -> None:
+    """Test that we can successfully logout a user."""
+    # First login to get the cookie
+    login_response = await client.post(
+        f"{BASE_ROUTE}/auth/login", json=user_login_payload
+    )
+    assert login_response.status_code == status.HTTP_200_OK
+    assert "token" in login_response.cookies
+
+    # Now logout
+    logout_response = await client.post(f"{BASE_ROUTE}/auth/logout")
+    assert logout_response.status_code == status.HTTP_200_OK
+
+    # Verify the response content
+    assert logout_response.json()["success"] == True
+
+    # Note: We cannot verify cookie deletion in tests because HttpX doesn't support
+    # direct inspection of Set-Cookie headers that clear cookies. In a real browser,
+    # this would clear the cookie.
+
+
+async def test_auth_flow_with_cookies(client: AsyncClient) -> None:
+    """Test the entire authentication flow using cookies."""
+    # First, login to get the auth cookie
+    login_response = await client.post(
+        f"{BASE_ROUTE}/auth/login", json=user_login_payload
+    )
+    assert login_response.status_code == status.HTTP_200_OK
+    assert "token" in login_response.cookies
+
+    # Create a new client with the cookies from the login response
+    auth_client = AsyncClient(cookies=login_response.cookies, base_url=client.base_url)
+
+    # Try to access a protected endpoint using the cookie
+    # We'll use a health endpoint as a placeholder since we don't have a protected endpoint in these tests
+    health_response = await client.get(f"{BASE_ROUTE}/health/ping")
+    assert health_response.status_code == status.HTTP_200_OK
+
+    # Now logout
+    logout_response = await client.post(f"{BASE_ROUTE}/auth/logout")
+    assert logout_response.status_code == status.HTTP_200_OK

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -1,0 +1,93 @@
+
+from .config import BASE_ROUTE
+import uuid
+import copy
+
+from httpx import AsyncClient
+
+from fastapi import status
+
+
+user_register_payload = {
+    "email": "adam@ufsit.club",
+    "password": "password123",
+    "name": "Adam Hassan",
+}
+
+user_login_payload = copy.deepcopy(user_register_payload)
+user_login_payload.pop("name")
+
+
+async def test_user_register(client: AsyncClient) -> None:
+    """Test that we get a 200 response when registering a user."""
+    response = await client.post(f"{BASE_ROUTE}/auth/register", json=user_register_payload)
+    assert response.status_code == status.HTTP_200_OK
+
+    uuid_response = response.json()["id"]
+    uuid_obj = uuid.UUID(uuid_response, version=4)
+    assert str(uuid_obj) == uuid_response
+
+async def test_duplicate_user_register(client: AsyncClient) -> None:
+    """Test that we get a 400 response when registering a user with the same email."""
+    response = await client.post(f"{BASE_ROUTE}/auth/register", json=user_register_payload)
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+    response_json = response.json()
+    assert response_json["detail"] == "User already exists"
+
+async def test_duplicate_user_diff_name_pass_register(client: AsyncClient) -> None:
+    """Test that we get a 400 response when registering a user with the same email but a different password and name."""
+    
+    new_user_register_payload = copy.deepcopy(user_register_payload)
+    new_user_register_payload["password"] = "newpassword123"
+    new_user_register_payload["name"] = "New Name"
+    
+    response = await client.post(f"{BASE_ROUTE}/auth/register", json=user_register_payload)
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+    response_json = response.json()
+    assert response_json["detail"] == "User already exists"
+
+async def test_user_register_invalid_payload(client: AsyncClient) -> None:
+    """Test that we get a 422 response when registering a user with an invalid payload."""
+    invalid_payload = copy.deepcopy(user_register_payload)
+    invalid_payload.pop("email")
+
+    response = await client.post(f"{BASE_ROUTE}/auth/register", json=invalid_payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    invalid_payload = copy.deepcopy(user_register_payload)
+    invalid_payload.pop("password")
+
+    response = await client.post(f"{BASE_ROUTE}/auth/register", json=invalid_payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    invalid_payload = copy.deepcopy(user_register_payload)
+    invalid_payload.pop("name")
+
+    response = await client.post(f"{BASE_ROUTE}/auth/register", json=invalid_payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+async def test_user_login_correct_pass(client: AsyncClient) -> None:
+    """Test that we get a 200 response when logging in a user and get a valid JWT."""
+    response = await client.post(f"{BASE_ROUTE}/auth/login", json=user_login_payload)
+    assert response.status_code == status.HTTP_200_OK
+
+    jwt = response.json()["token"]
+    assert jwt
+
+async def test_user_login_incorrect_pass(client: AsyncClient) -> None:
+    """Test that we get a 401 response when logging in a user with an incorrect password."""
+    invalid_payload = copy.deepcopy(user_login_payload)
+    invalid_payload["password"] = "incorrectpassword"
+
+    response = await client.post(f"{BASE_ROUTE}/auth/login", json=invalid_payload)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+async def test_nonexistent_user_login(client: AsyncClient) -> None:
+    """Test that we get a 401 response when logging in a user that doesn't exist."""
+    invalid_payload = copy.deepcopy(user_login_payload)
+    invalid_payload["email"] = "alex@ufsit.club"
+
+    response = await client.post(f"{BASE_ROUTE}/auth/login", json=invalid_payload)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import uuid
-from typing import Any
 
 import pytest
 from fastapi import status
@@ -12,53 +11,24 @@ from src.app.schemas.template_host_schema import TemplateHostSchema
 from src.app.schemas.template_subnet_schema import TemplateSubnetHeaderSchema
 
 from .config import BASE_ROUTE
+from .config import base_user_register_payload, base_user_login_payload
+from .config import (
+    valid_range_payload,
+    valid_vpc_payload,
+    valid_subnet_payload,
+    valid_host_payload,
+)
 
 ###### Test /template/range #######
 
-# Valid payload for comparison
-valid_range_payload: dict[str, Any] = {
-    "vpcs": [
-        {
-            "cidr": "192.168.0.0/16",
-            "name": "example-vpc-1",
-            "subnets": [
-                {
-                    "cidr": "192.168.1.0/24",
-                    "name": "example-subnet-1",
-                    "hosts": [
-                        {
-                            "hostname": "example-host-1",
-                            "os": "debian_11",
-                            "spec": "tiny",
-                            "size": 8,
-                            "tags": ["web", "linux"],
-                        }
-                    ],
-                }
-            ],
-        }
-    ],
-    "provider": "aws",
-    "name": "example-range-1",
-    "vnc": False,
-    "vpn": False,
-}
-
-valid_vpc_payload = copy.deepcopy(valid_range_payload["vpcs"][0])
-valid_subnet_payload = copy.deepcopy(valid_vpc_payload["subnets"][0])
-valid_host_payload = copy.deepcopy(valid_subnet_payload["hosts"][0])
-
-user_register_payload = {
-    "email": "test-templates@ufsit.club",
-    "password": "password123",
-    "name": "Adam Hassan",
-}
-
-user_login_payload = copy.deepcopy(user_register_payload)
-user_login_payload.pop("name")
-
 # global auth token to be used in all tests
 auth_token = None
+
+user_register_payload = copy.deepcopy(base_user_register_payload)
+user_login_payload = copy.deepcopy(base_user_login_payload)
+
+user_register_payload["email"] = "test-templates@ufsit.club"
+user_login_payload["email"] = user_register_payload["email"]
 
 
 async def test_get_auth_token(client: AsyncClient) -> None:

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -69,14 +69,18 @@ async def test_get_auth_token(client: AsyncClient) -> None:
 
     assert response.status_code == status.HTTP_200_OK
 
-    response = await client.post(f"{BASE_ROUTE}/auth/login", json=user_login_payload)
-    assert response.status_code == status.HTTP_200_OK
+    login_response = await client.post(
+        f"{BASE_ROUTE}/auth/login", json=user_login_payload
+    )
+    assert login_response.status_code == status.HTTP_200_OK
+
     global auth_token
-    auth_token = response.json()["token"]
+    auth_token = login_response.cookies.get("token")
 
 
 async def test_template_range_get_all_empty_list(client: AsyncClient) -> None:
     """Test that we get a 404 response when there are no range templates."""
+    # For backward compatibility, continue using the Authorization header
     client.headers.update({"Authorization": f"Bearer {auth_token}"})
     response = await client.get(f"{BASE_ROUTE}/templates/ranges")
     print(response.json())
@@ -1147,7 +1151,7 @@ async def test_user_cant_access_other_templates(client: AsyncClient) -> None:
     )
     assert response.status_code == status.HTTP_200_OK
 
-    new_auth_token = response.json()["token"]
+    new_auth_token = response.cookies.get("token")
 
     client.headers.update({"Authorization": f"Bearer {new_auth_token}"})
 

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -58,11 +58,12 @@ user_login_payload.pop("name")
 # global auth token to be used in all tests
 auth_token = None
 
+
 async def test_get_auth_token(client: AsyncClient) -> None:
     """Get the authentication token for the test user. This must run first to provide the global auth token for the other tests"""
     response = await client.post(
-        f"{BASE_ROUTE}/auth/register", json=user_register_payload)
-
+        f"{BASE_ROUTE}/auth/register", json=user_register_payload
+    )
 
     assert response.status_code == status.HTTP_200_OK
 
@@ -70,7 +71,7 @@ async def test_get_auth_token(client: AsyncClient) -> None:
     assert response.status_code == status.HTTP_200_OK
     global auth_token
     auth_token = response.json()["token"]
-    
+
 
 async def test_template_range_get_all_empty_list(client: AsyncClient) -> None:
     """Test that we get a 404 response when there are no range templates."""
@@ -667,26 +668,32 @@ async def test_user_cant_access_other_templates(client: AsyncClient) -> None:
     """Test that we get a 404 response when trying to access another user's templates."""
     client.headers.update({"Authorization": f"Bearer {auth_token}"})
     response = await client.get(f"{BASE_ROUTE}/templates/ranges")
-    template_ids = set(t['id'] for t in response.json())
+    template_ids = set(t["id"] for t in response.json())
 
     new_user_register_payload = copy.deepcopy(user_register_payload)
     new_user_register_payload["email"] = "test-templates-2@ufsit.club"
 
-    response = await client.post(f"{BASE_ROUTE}/auth/register", json=new_user_register_payload)
+    response = await client.post(
+        f"{BASE_ROUTE}/auth/register", json=new_user_register_payload
+    )
     assert response.status_code == status.HTTP_200_OK
 
-    response = await client.post(f"{BASE_ROUTE}/auth/login", json=new_user_register_payload)
+    response = await client.post(
+        f"{BASE_ROUTE}/auth/login", json=new_user_register_payload
+    )
     assert response.status_code == status.HTTP_200_OK
 
     new_auth_token = response.json()["token"]
 
     client.headers.update({"Authorization": f"Bearer {new_auth_token}"})
 
-    response = await client.post(f"{BASE_ROUTE}/templates/ranges", json=valid_range_payload)
+    response = await client.post(
+        f"{BASE_ROUTE}/templates/ranges", json=valid_range_payload
+    )
     assert response.status_code == status.HTTP_200_OK
 
     response = await client.get(f"{BASE_ROUTE}/templates/ranges")
-    new_template_ids = set(t['id'] for t in response.json())
+    new_template_ids = set(t["id"] for t in response.json())
 
     assert template_ids.isdisjoint(new_template_ids)
 

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -1165,6 +1165,7 @@ async def test_user_cant_access_other_templates(client: AsyncClient) -> None:
         response = await client.get(f"{BASE_ROUTE}/templates/ranges/{template_id}")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+
 async def test_template_host_delete(client: AsyncClient) -> None:
     """Test that we get can successfully delete host templates."""
     client.headers.update({"Authorization": f"Bearer {auth_token}"})

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -47,7 +47,7 @@ valid_subnet_payload = copy.deepcopy(valid_vpc_payload["subnets"][0])
 valid_host_payload = copy.deepcopy(valid_subnet_payload["hosts"][0])
 
 user_register_payload = {
-    "email": "adam@ufsit.club",
+    "email": "test-templates@ufsit.club",
     "password": "password123",
     "name": "Adam Hassan",
 }
@@ -64,7 +64,7 @@ async def test_get_auth_token(client: AsyncClient) -> None:
         f"{BASE_ROUTE}/auth/register", json=user_register_payload)
 
 
-    assert response.status_code == status.HTTP_200_OK or response.status_code == status.HTTP_409_CONFLICT
+    assert response.status_code == status.HTTP_200_OK
 
     response = await client.post(f"{BASE_ROUTE}/auth/login", json=user_login_payload)
     assert response.status_code == status.HTTP_200_OK

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -424,6 +424,7 @@ async def test_template_range_host_size_too_small(client: AsyncClient) -> None:
 
 async def test_template_range_delete(client: AsyncClient) -> None:
     """Test that we can sucessfully delete a range template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     response = await client.post(
         f"{BASE_ROUTE}/templates/ranges", json=valid_range_payload
     )
@@ -443,6 +444,7 @@ async def test_template_range_delete(client: AsyncClient) -> None:
 
 async def test_template_range_delete_invalid_uuid(client: AsyncClient) -> None:
     """Test that we get a 400 when providing an invalid UUID4."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     invalid_uuid = str(uuid.uuid4())[:-1]
     response = await client.delete(f"{BASE_ROUTE}/templates/ranges/{invalid_uuid}")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -451,6 +453,7 @@ async def test_template_range_delete_invalid_uuid(client: AsyncClient) -> None:
 
 async def test_template_ramge_delete_non_existent(client: AsyncClient) -> None:
     """Test that we get a 404 when trying to delete a nonexistent range template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     random_uuid = str(uuid.uuid4())
     response = await client.delete(f"{BASE_ROUTE}/templates/ranges/{random_uuid}")
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -465,6 +468,7 @@ async def test_template_range_delete_non_standalone(
     were the highest level template and as a result the is_standalone() method was
     hardcoded to always return True for compatibility. This is why the method is mocked.
     """
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     # Patch range model method to return False
     monkeypatch.setattr(TemplateRangeModel, "is_standalone", lambda self: False)
 
@@ -486,6 +490,7 @@ async def test_template_range_delete_cascade_vpcs_subnets_and_hosts(
     client: AsyncClient,
 ) -> None:
     """Test that when we delete a range template it cascades and deletes the associated vpcs, subnets, and hosts."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     # Get all existing hosts
     response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
 
@@ -691,6 +696,7 @@ async def test_template_vpc_get_nonexistent_vpc(client: AsyncClient) -> None:
 
 async def test_template_vpc_delete(client: AsyncClient) -> None:
     """Test that we can sucessfully delete a VPC template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     response = await client.post(f"{BASE_ROUTE}/templates/vpcs", json=valid_vpc_payload)
     assert response.status_code == status.HTTP_200_OK
 
@@ -708,6 +714,7 @@ async def test_template_vpc_delete(client: AsyncClient) -> None:
 
 async def test_template_vpc_delete_invalid_uuid(client: AsyncClient) -> None:
     """Test that we get a 400 when providing an invalid UUID4."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     invalid_uuid = str(uuid.uuid4())[:-1]
     response = await client.delete(f"{BASE_ROUTE}/templates/vpcs/{invalid_uuid}")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -716,6 +723,7 @@ async def test_template_vpc_delete_invalid_uuid(client: AsyncClient) -> None:
 
 async def test_template_vpc_delete_non_existent(client: AsyncClient) -> None:
     """Test that we get a 404 when trying to delete a nonexistent VPC template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     random_uuid = str(uuid.uuid4())
     response = await client.delete(f"{BASE_ROUTE}/templates/vpcs/{random_uuid}")
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -723,6 +731,7 @@ async def test_template_vpc_delete_non_existent(client: AsyncClient) -> None:
 
 async def test_template_vpc_delete_non_standalone(client: AsyncClient) -> None:
     """Test that we get a 409 when trying to delete a non-standalone VPC template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     # Get all existing subnets
     response = await client.get(f"{BASE_ROUTE}/templates/vpcs?standalone_only=false")
 
@@ -760,6 +769,7 @@ async def test_template_vpc_delete_cascade_subnets_and_hosts(
     client: AsyncClient,
 ) -> None:
     """Test that when we delete a subnet template it cascades and deletes the associated hosts."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     # Get all existing hosts
     response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
 
@@ -936,6 +946,7 @@ async def test_template_subnet_get_nonexistent_subnet(client: AsyncClient) -> No
 
 async def test_template_subnet_delete(client: AsyncClient) -> None:
     """Test that we can sucessfully delete a subnet template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     response = await client.post(
         f"{BASE_ROUTE}/templates/subnets", json=valid_subnet_payload
     )
@@ -955,6 +966,7 @@ async def test_template_subnet_delete(client: AsyncClient) -> None:
 
 async def test_template_subnet_delete_invalid_uuid(client: AsyncClient) -> None:
     """Test that we get a 400 when providing an invalid UUID4."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     invalid_uuid = str(uuid.uuid4())[:-1]
     response = await client.delete(f"{BASE_ROUTE}/templates/subnets/{invalid_uuid}")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -963,6 +975,7 @@ async def test_template_subnet_delete_invalid_uuid(client: AsyncClient) -> None:
 
 async def test_template_subnet_delete_non_existent(client: AsyncClient) -> None:
     """Test that we get a 404 when trying to delete a nonexistent subnet template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     random_uuid = str(uuid.uuid4())
     response = await client.delete(f"{BASE_ROUTE}/templates/subnets/{random_uuid}")
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -970,6 +983,7 @@ async def test_template_subnet_delete_non_existent(client: AsyncClient) -> None:
 
 async def test_template_subnet_delete_non_standalone(client: AsyncClient) -> None:
     """Test that we get a 409 when trying to delete a non-standalone subnet template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     # Get all existing subnets
     response = await client.get(f"{BASE_ROUTE}/templates/subnets?standalone_only=false")
 
@@ -1005,6 +1019,7 @@ async def test_template_subnet_delete_non_standalone(client: AsyncClient) -> Non
 
 async def test_template_subnet_delete_cascade_hosts(client: AsyncClient) -> None:
     """Test that when we delete a subnet template it cascades and deletes the associated hosts."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     # Get all existing hosts
     response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
 
@@ -1152,6 +1167,7 @@ async def test_user_cant_access_other_templates(client: AsyncClient) -> None:
 
 async def test_template_host_delete(client: AsyncClient) -> None:
     """Test that we get can successfully delete host templates."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     response = await client.post(
         f"{BASE_ROUTE}/templates/hosts", json=valid_host_payload
     )
@@ -1171,6 +1187,7 @@ async def test_template_host_delete(client: AsyncClient) -> None:
 
 async def test_template_host_delete_invalid_uuid(client: AsyncClient) -> None:
     """Test that we get a 400 when providing an invalid UUID4."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     invalid_uuid = str(uuid.uuid4())[:-1]
     response = await client.delete(f"{BASE_ROUTE}/templates/hosts/{invalid_uuid}")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -1179,6 +1196,7 @@ async def test_template_host_delete_invalid_uuid(client: AsyncClient) -> None:
 
 async def test_template_host_delete_non_existent(client: AsyncClient) -> None:
     """Test that we get a 404 when trying to delete a nonexistent host."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     random_uuid = str(uuid.uuid4())
     response = await client.delete(f"{BASE_ROUTE}/templates/hosts/{random_uuid}")
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -1186,6 +1204,7 @@ async def test_template_host_delete_non_existent(client: AsyncClient) -> None:
 
 async def test_template_host_delete_non_standalone(client: AsyncClient) -> None:
     """Test that we get a 409 when trying to delete a non-standalone template."""
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
     # Get all existing hosts
     response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
 

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -31,6 +31,8 @@ aws_secrets_payload = {
 azure_secrets_payload = {
     "azure_client_id": "00000000-0000-0000-0000-000000000000",
     "azure_client_secret": "example-client-secret-value",
+    "azure_tenant_id": "00000000-0000-0000-0000-000000000000",
+    "azure_subscription_id": "00000000-0000-0000-0000-000000000000",
 }
 
 # Global auth token to be used in all tests

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -4,39 +4,21 @@ from fastapi import status
 from httpx import AsyncClient
 
 from .config import BASE_ROUTE
-
-# Test user credentials
-user_register_payload = {
-    "email": "test-users@ufsit.club",
-    "password": "password123",
-    "name": "Test User",
-}
-
-user_login_payload = copy.deepcopy(user_register_payload)
-user_login_payload.pop("name")
-
-# Test data for password update
-password_update_payload = {
-    "current_password": "password123",
-    "new_password": "newpassword123",
-}
-
-# Test data for AWS secrets
-aws_secrets_payload = {
-    "aws_access_key": "AKIAIOSFODNN7EXAMPLE",
-    "aws_secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-}
-
-# Test data for Azure secrets
-azure_secrets_payload = {
-    "azure_client_id": "00000000-0000-0000-0000-000000000000",
-    "azure_client_secret": "example-client-secret-value",
-    "azure_tenant_id": "00000000-0000-0000-0000-000000000000",
-    "azure_subscription_id": "00000000-0000-0000-0000-000000000000",
-}
+from .config import (
+    base_user_register_payload,
+    base_user_login_payload,
+    password_update_payload,
+)
+from .config import aws_secrets_payload, azure_secrets_payload
 
 # Global auth token to be used in all tests
 auth_token = None
+
+user_register_payload = copy.deepcopy(base_user_register_payload)
+user_login_payload = copy.deepcopy(base_user_login_payload)
+
+user_register_payload["email"] = "test-users@ufsit.club"
+user_login_payload["email"] = user_register_payload["email"]
 
 
 async def test_get_auth_token(client: AsyncClient) -> None:

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -117,8 +117,8 @@ async def test_update_password_with_incorrect_current(client: AsyncClient) -> No
     assert update_response.json()["detail"] == "Current password is incorrect"
 
 
-async def test_secrets_operations(client: AsyncClient) -> None:
-    """Test all secret-related operations."""
+async def test_get_initial_secrets_status(client: AsyncClient) -> None:
+    """Test getting the initial secrets status."""
     # Set the authorization header with the token
     client.headers.update({"Authorization": f"Bearer {auth_token}"})
 
@@ -127,8 +127,13 @@ async def test_secrets_operations(client: AsyncClient) -> None:
     assert status_response.status_code == status.HTTP_200_OK
 
     # Check the status response is valid JSON
-    # (not asserting specific values as test order may vary)
     _ = status_response.json()
+
+
+async def test_update_aws_credentials(client: AsyncClient) -> None:
+    """Test updating AWS credentials."""
+    # Set the authorization header with the token
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
 
     # Add AWS credentials
     aws_response = await client.post(
@@ -145,6 +150,12 @@ async def test_secrets_operations(client: AsyncClient) -> None:
     assert aws_status["aws"]["has_credentials"] is True
     assert "created_at" in aws_status["aws"]
 
+
+async def test_update_azure_credentials(client: AsyncClient) -> None:
+    """Test updating Azure credentials."""
+    # Set the authorization header with the token
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
+
     # Add Azure credentials
     azure_response = await client.post(
         f"{BASE_ROUTE}/users/me/secrets/azure", json=azure_secrets_payload
@@ -152,14 +163,29 @@ async def test_secrets_operations(client: AsyncClient) -> None:
     assert azure_response.status_code == status.HTTP_200_OK
     assert azure_response.json()["message"] == "Azure credentials updated successfully"
 
-    # Final status check
-    final_status_response = await client.get(f"{BASE_ROUTE}/users/me/secrets")
-    assert final_status_response.status_code == status.HTTP_200_OK
+    # Check updated status
+    status_response = await client.get(f"{BASE_ROUTE}/users/me/secrets")
+    assert status_response.status_code == status.HTTP_200_OK
 
-    final_status = final_status_response.json()
-    assert final_status["aws"]["has_credentials"] is True
-    assert final_status["azure"]["has_credentials"] is True
-    assert "created_at" in final_status["azure"]
+    azure_status = status_response.json()
+    assert azure_status["azure"]["has_credentials"] is True
+    assert "created_at" in azure_status["azure"]
+
+
+async def test_both_provider_credentials_status(client: AsyncClient) -> None:
+    """Test that status shows both provider credentials when set."""
+    # Set the authorization header with the token
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+    # Check final status with both credentials
+    status_response = await client.get(f"{BASE_ROUTE}/users/me/secrets")
+    assert status_response.status_code == status.HTTP_200_OK
+
+    provider_status = status_response.json()
+    assert provider_status["aws"]["has_credentials"] is True
+    assert provider_status["azure"]["has_credentials"] is True
+    assert "created_at" in provider_status["aws"]
+    assert "created_at" in provider_status["azure"]
 
 
 async def test_unauthenticated_access(client: AsyncClient) -> None:

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -1,0 +1,210 @@
+import copy
+
+from fastapi import status
+from httpx import AsyncClient
+
+from .config import BASE_ROUTE
+
+# Test user credentials
+user_register_payload = {
+    "email": "test-users@ufsit.club",
+    "password": "password123",
+    "name": "Test User",
+}
+
+user_login_payload = copy.deepcopy(user_register_payload)
+user_login_payload.pop("name")
+
+# Test data for password update
+password_update_payload = {
+    "current_password": "password123",
+    "new_password": "newpassword123",
+}
+
+# Test data for AWS secrets
+aws_secrets_payload = {
+    "aws_access_key": "AKIAIOSFODNN7EXAMPLE",
+    "aws_secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+}
+
+# Test data for Azure secrets
+azure_secrets_payload = {
+    "azure_client_id": "00000000-0000-0000-0000-000000000000",
+    "azure_client_secret": "example-client-secret-value",
+}
+
+# Global auth token to be used in all tests
+auth_token = None
+
+
+async def test_get_auth_token(client: AsyncClient) -> None:
+    """Get authentication token for the test user.
+
+    This must run first to provide the global auth token for other tests.
+    """
+    # First register a user
+    register_response = await client.post(
+        f"{BASE_ROUTE}/auth/register", json=user_register_payload
+    )
+    assert register_response.status_code == status.HTTP_200_OK
+
+    # Login to get token
+    login_response = await client.post(
+        f"{BASE_ROUTE}/auth/login", json=user_login_payload
+    )
+    assert login_response.status_code == status.HTTP_200_OK
+    assert "token" in login_response.cookies
+
+    # Set global auth token
+    global auth_token
+    auth_token = login_response.cookies.get("token")
+
+
+async def test_get_user_info(client: AsyncClient) -> None:
+    """Test retrieving the current user's information."""
+    # Set the authorization header with the token
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+    # Get user info
+    response = await client.get(f"{BASE_ROUTE}/users/me")
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify the response contains the expected user information
+    user_info = response.json()
+    assert user_info["email"] == user_register_payload["email"]
+    assert user_info["name"] == user_register_payload["name"]
+
+
+async def test_update_password_flow(client: AsyncClient) -> None:
+    """Test the complete password update flow."""
+    # Set the authorization header with the token
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+    # Update password
+    update_response = await client.post(
+        f"{BASE_ROUTE}/users/me/password", json=password_update_payload
+    )
+    assert update_response.status_code == status.HTTP_200_OK
+    assert update_response.json()["message"] == "Password updated successfully"
+
+    # Try to login with new password
+    new_login_payload = copy.deepcopy(user_login_payload)
+    new_login_payload["password"] = password_update_payload["new_password"]
+
+    new_login_response = await client.post(
+        f"{BASE_ROUTE}/auth/login", json=new_login_payload
+    )
+    assert new_login_response.status_code == status.HTTP_200_OK
+
+    # Get the new token
+    new_token = new_login_response.cookies.get("token")
+
+    # Reset password back for other tests
+    reset_payload = {
+        "current_password": password_update_payload["new_password"],
+        "new_password": password_update_payload["current_password"],
+    }
+
+    # Use the new token to reset the password
+    client.headers.update({"Authorization": f"Bearer {new_token}"})
+    reset_response = await client.post(
+        f"{BASE_ROUTE}/users/me/password", json=reset_payload
+    )
+    assert reset_response.status_code == status.HTTP_200_OK
+
+    # Restore the global token after test is done
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+
+async def test_update_password_with_incorrect_current(client: AsyncClient) -> None:
+    """Test password update with incorrect current password."""
+    # Set the authorization header with the token
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+    # Try update with wrong current password
+    invalid_payload = copy.deepcopy(password_update_payload)
+    # Using an incorrect password to test validation - not a security risk
+    invalid_payload["current_password"] = "incorrect-password-for-testing"  # noqa: S105
+
+    update_response = await client.post(
+        f"{BASE_ROUTE}/users/me/password", json=invalid_payload
+    )
+    assert update_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert update_response.json()["detail"] == "Current password is incorrect"
+
+
+async def test_secrets_operations(client: AsyncClient) -> None:
+    """Test all secret-related operations."""
+    # Set the authorization header with the token
+    client.headers.update({"Authorization": f"Bearer {auth_token}"})
+
+    # Check initial secrets status
+    status_response = await client.get(f"{BASE_ROUTE}/users/me/secrets")
+    assert status_response.status_code == status.HTTP_200_OK
+
+    # Check the status response is valid JSON
+    # (not asserting specific values as test order may vary)
+    _ = status_response.json()
+
+    # Add AWS credentials
+    aws_response = await client.post(
+        f"{BASE_ROUTE}/users/me/secrets/aws", json=aws_secrets_payload
+    )
+    assert aws_response.status_code == status.HTTP_200_OK
+    assert aws_response.json()["message"] == "AWS credentials updated successfully"
+
+    # Check updated status
+    updated_status_response = await client.get(f"{BASE_ROUTE}/users/me/secrets")
+    assert updated_status_response.status_code == status.HTTP_200_OK
+
+    aws_status = updated_status_response.json()
+    assert aws_status["aws"]["has_credentials"] is True
+    assert "created_at" in aws_status["aws"]
+
+    # Add Azure credentials
+    azure_response = await client.post(
+        f"{BASE_ROUTE}/users/me/secrets/azure", json=azure_secrets_payload
+    )
+    assert azure_response.status_code == status.HTTP_200_OK
+    assert azure_response.json()["message"] == "Azure credentials updated successfully"
+
+    # Final status check
+    final_status_response = await client.get(f"{BASE_ROUTE}/users/me/secrets")
+    assert final_status_response.status_code == status.HTTP_200_OK
+
+    final_status = final_status_response.json()
+    assert final_status["aws"]["has_credentials"] is True
+    assert final_status["azure"]["has_credentials"] is True
+    assert "created_at" in final_status["azure"]
+
+
+async def test_unauthenticated_access(client: AsyncClient) -> None:
+    """Test that unauthenticated users cannot access protected endpoints."""
+    # Clear any authorization headers
+    client.headers.clear()
+
+    # Try to access user info without authentication
+    response = await client.get(f"{BASE_ROUTE}/users/me")
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    # Try to update password without authentication
+    response = await client.post(
+        f"{BASE_ROUTE}/users/me/password", json=password_update_payload
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    # Try to get secrets status without authentication
+    response = await client.get(f"{BASE_ROUTE}/users/me/secrets")
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    # Try to update AWS secrets without authentication
+    response = await client.post(
+        f"{BASE_ROUTE}/users/me/secrets/aws", json=aws_secrets_payload
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    # Try to update Azure secrets without authentication
+    response = await client.post(
+        f"{BASE_ROUTE}/users/me/secrets/azure", json=azure_secrets_payload
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,1 +1,1 @@
-"""Core application tests for the OpenLabsX API."""
+"""Core application tests for the OpenLabs API."""

--- a/tests/core/cdktf/__init__.py
+++ b/tests/core/cdktf/__init__.py
@@ -1,1 +1,1 @@
-"""CDKTF tests for the OpenLabsX API."""
+"""CDKTF tests for the OpenLabs API."""

--- a/tests/core/cdktf/aws/__init__.py
+++ b/tests/core/cdktf/aws/__init__.py
@@ -1,1 +1,1 @@
-"""AWS CDKTF tests for the OpenLabsX API."""
+"""AWS CDKTF tests for the OpenLabs API."""

--- a/tests/validators/__init__.py
+++ b/tests/validators/__init__.py
@@ -1,1 +1,1 @@
-"""Validator tests for the OpenLabsX API."""
+"""Validator tests for the OpenLabs API."""


### PR DESCRIPTION
## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.

## Description

- Add user models and schemas
- Add cloud secret models and schemas
- Add concept of ownership to templates and deployed ranges
- Add login and register endpoints
- Change all template tests to be authenticated
- Add unit tests for login and register endpoints
- Allow admin to read/deploy anything
- Add endpoints for reading user info
- Add endpoints for checking user secrets
- Add endpoints for adding secrets to DB
- Encrypt secrets (See https://github.com/OpenLabsHQ/API/issues/26#issuecomment-2687056674)

Scheduled for later:
- Set up field for readers of templates and ranges (list of uuids)
	- Allow users who can read a template to deploy a range from it
- Implement "community templates" that are world readable
    - Enforce templates having an owner
    - Add `is_public` to templates
- Add missing tests for is_admin. I need to mock the admin being added to the DB somehow
- Figure out how to get better error codes for invalid JWT. Currently getting a 422 no matter what. 
- Verify secrets on add to the db using boto3. The idea would be we have an abstract class function and depending on the cloud provider that specific sdk library is used (boto3 for aws, equivalent for azure, gcp, etc.) with a child class function that will be called to authenticate to the provider account.

Fixes:
#26
#14 
#43 
