### PR TITLE
increase number of worker threads so we can get response while deploy…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ COPY .git /code/.git
 
 EXPOSE 80
 
-CMD ["uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "80", "--workers", "4"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
       - fastapi_network
     command: [
       "python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "--wait-for-client",
-      "-m", "uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "80", "--reload"
+      "-m", "uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "80", "--reload", "--workers", "4"
     ]
 
 volumes:


### PR DESCRIPTION
… is happening

## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.

## Description

FastAPI uses one worker thread by default. When doing a deploy, terraform locked up the entire API. 

This PR increases the number of worker threads to 4. 
